### PR TITLE
3D ANSI block-style banner and animated spinner for launcher

### DIFF
--- a/rain_lab.py
+++ b/rain_lab.py
@@ -19,38 +19,45 @@ ANSI_CYAN = "\033[96m"
 ANSI_BLUE = "\033[94m"
 ANSI_MAGENTA = "\033[95m"
 ANSI_GREEN = "\033[92m"
+ANSI_YELLOW = "\033[93m"
+ANSI_DIM = "\033[90m"
 
 BANNER_LINES = [
-    "██╗   ██╗███████╗██████╗ ███████╗██████╗ ██████╗ ██╗   ██╗███╗   ██╗ █████╗ ███╗   ███╗██╗ ██████╗███████╗",
-    "██║   ██║██╔════╝██╔══██╗██╔════╝██╔══██╗██╔══██╗╚██╗ ██╔╝████╗  ██║██╔══██╗████╗ ████║██║██╔════╝██╔════╝",
-    "██║   ██║█████╗  ██████╔╝███████╗██████╔╝██║  ██║ ╚████╔╝ ██╔██╗ ██║███████║██╔████╔██║██║██║     ███████╗",
-    "╚██╗ ██╔╝██╔══╝  ██╔══██╗╚════██║██╔══██╗██║  ██║  ╚██╔╝  ██║╚██╗██║██╔══██║██║╚██╔╝██║██║██║     ╚════██║",
-    " ╚████╔╝ ███████╗██║  ██║███████║██║  ██║██████╔╝   ██║   ██║ ╚████║██║  ██║██║ ╚═╝ ██║██║╚██████╗███████║",
-    "  ╚═══╝  ╚══════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═════╝    ╚═╝   ╚═╝  ╚═══╝╚═╝  ╚═╝╚═╝     ╚═╝╚═╝ ╚═════╝╚══════╝",
-    "▓▓▓▓▓▓▓▓▓▓  VERS3DYNAMICS  ▓▓▓▓▓▓▓▓▓▓          ▓▓▓▓▓▓▓  R.A.I.N. Lab  ▓▓▓▓▓▓▓",
+    "██████╗  █████╗ ██╗███╗   ██╗    ██╗      █████╗ ██████╗ ",
+    "██╔══██╗██╔══██╗██║████╗  ██║    ██║     ██╔══██╗██╔══██╗",
+    "██████╔╝███████║██║██╔██╗ ██║    ██║     ███████║██████╔╝",
+    "██╔══██╗██╔══██║██║██║╚██╗██║    ██║     ██╔══██║██╔══██╗",
+    "██║  ██║██║  ██║██║██║ ╚████║    ███████╗██║  ██║██████╔╝",
+    "╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝    ╚══════╝╚═╝  ╚═╝╚═════╝ ",
+    "▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓",
+    "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ V E R S 3 D Y N A M I C S ▒▒▒▒▒▒▒▒▒▒▒▒",
 ]
 
 
 def _print_banner() -> None:
-    colors = [ANSI_CYAN, ANSI_BLUE, ANSI_MAGENTA, ANSI_BLUE, ANSI_CYAN, ANSI_BLUE, ANSI_GREEN]
+    colors = [ANSI_CYAN, ANSI_BLUE, ANSI_MAGENTA, ANSI_BLUE, ANSI_CYAN, ANSI_GREEN, ANSI_BLUE, ANSI_YELLOW]
     for line, color in zip(BANNER_LINES, colors):
+        print(f"{ANSI_DIM} {line}{ANSI_RESET}", flush=True)
         print(f"{color}{line}{ANSI_RESET}", flush=True)
 
 
-def _spinner(message: str, duration_s: float = 0.9) -> None:
+def _spinner(message: str, duration_s: float = 1.25) -> None:
     if not sys.stdout.isatty():
         print(f"{ANSI_CYAN}{message}...{ANSI_RESET}", flush=True)
         return
 
-    frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
-    end_time = time.time() + max(0.1, duration_s)
+    frames = ["▱▱▱", "▰▱▱", "▰▰▱", "▰▰▰", "▱▰▰", "▱▱▰"]
+    colors = [ANSI_CYAN, ANSI_BLUE, ANSI_MAGENTA, ANSI_GREEN, ANSI_YELLOW]
+    end_time = time.time() + max(0.2, duration_s)
     i = 0
     while time.time() < end_time:
         frame = frames[i % len(frames)]
-        print(f"\r{ANSI_CYAN}{frame} {message}{ANSI_RESET}", end="", flush=True)
+        color = colors[i % len(colors)]
+        pulse = "•" * ((i % 3) + 1)
+        print(f"\r{color}{frame} {message} {pulse}{ANSI_RESET}   ", end="", flush=True)
         i += 1
-        time.sleep(0.08)
-    print(f"\r{ANSI_GREEN}✔ {message}{ANSI_RESET}")
+        time.sleep(0.09)
+    print(f"\r{ANSI_GREEN}✔ {message}{ANSI_RESET}   ")
 
 
 def _split_passthrough_args(argv: list[str]) -> tuple[list[str], list[str]]:


### PR DESCRIPTION
### Motivation
- Improve the launcher startup appearance with a more impactful 3D block-style ASCII banner and animated boot feedback.
- Add richer ANSI styling to achieve a colored foreground and dimmed shadow for depth.

### Description
- Replaced the original ASCII banner in `rain_lab.py` with a multi-line 3D block-style `BANNER_LINES` design and added `ANSI_YELLOW` and `ANSI_DIM` color constants to support the look.
- Updated `_print_banner()` to render a dim “shadow” pass before printing the colored foreground to create a 3D depth effect.
- Overhauled `_spinner()` to use block-progress frames, cycle colors, add pulse dots, and increased default duration for a smoother animated boot experience.
- Kept command-building and argument parsing logic unchanged.

### Testing
- Ran `python -m py_compile rain_lab.py` which succeeded with no syntax errors.
- Executed a smoke test by importing and running `from rain_lab import _print_banner, _spinner` and invoking `_print_banner()` and `_spinner('Booting VERS3DYNAMICS R.A.I.N. Lab launcher', duration_s=0.25)`, which produced the expected colored banner and animated spinner output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1b6c5e2c83328afa2c051d916e2c)