### PR TITLE
Suppress raw LLM dumps, improve import diagnostics, and add dotenv fallback

### DIFF
--- a/rain_lab_meeting.py
+++ b/rain_lab_meeting.py
@@ -45,9 +45,18 @@ if "--help" not in sys.argv and "-h" not in sys.argv:
         from rlm import RLM
         import rlm as _rlm_mod
         print(f"Using RLM from: {_rlm_mod.__file__}")
-    except ImportError:
+    except ImportError as e:
+        missing_dep = getattr(e, "name", None)
         print(f"❌ CRITICAL ERROR: Could not import 'rlm' from {TARGET_PATH}")
-        print("Ensure the 'rlm' folder is inside 'james_library'.")
+        print("Checked sys.path entries:")
+        print(f"  - {TARGET_PATH}")
+        print(f"  - {os.path.join(TARGET_PATH, 'rlm-main')}")
+        print(f"  - {os.path.join(TARGET_PATH, 'rlm-main', 'rlm-main')}")
+        if missing_dep:
+            print(f"Missing Python dependency: {missing_dep}")
+            print("Install it in this same Python env and re-run.")
+        else:
+            print(f"ImportError details: {e}")
         sys.exit(1)
 
 import io
@@ -767,7 +776,7 @@ BEGIN EXECUTION IMMEDIATELY.
                 "setup_code": setup_code
             },
             custom_system_prompt=custom_prompt,
-            verbose=True
+            verbose=False
         )
         print("   ✓ RLM initialized with read_paper() and search_web()")
     

--- a/rlm-main/rlm-main/dotenv/__init__.py
+++ b/rlm-main/rlm-main/dotenv/__init__.py
@@ -1,0 +1,37 @@
+"""Minimal local fallback for python-dotenv.
+
+This keeps rlm importable in environments where python-dotenv is absent.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def load_dotenv(dotenv_path: str | os.PathLike[str] | None = None, override: bool = False) -> bool:
+    """Load KEY=VALUE pairs from a .env file into os.environ.
+
+    Returns True when a dotenv file was found and parsed, otherwise False.
+    """
+
+    path = Path(dotenv_path) if dotenv_path is not None else Path.cwd() / ".env"
+    if not path.exists() or not path.is_file():
+        return False
+
+    for raw_line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+
+        if not key:
+            continue
+        if key in os.environ and not override:
+            continue
+        os.environ[key] = value
+
+    return True


### PR DESCRIPTION
### Motivation
- Prevent noisy raw LLM/debug dumps (which leaked assistant-style refusal text) from appearing in the meeting console by disabling the RLM client verbose output.
- Make failures to import the local `rlm` package easier to diagnose by printing inspected `sys.path` entries and any missing dependency name.
- Provide a minimal `python-dotenv` fallback so `rlm` can import in environments where `python-dotenv` is not installed.

### Description
- Set `verbose=False` when constructing `RLM` in `rain_lab_meeting.py` to stop printing the raw `LLM Response` debug block to stdout.
- Improve the `ImportError` handling in `rain_lab_meeting.py` to print the checked `sys.path` entries and, when available, the missing dependency name or the full exception details.
- Add a lightweight `rlm-main/rlm-main/dotenv/__init__.py` that implements `load_dotenv()` as a local fallback to parse `.env` files into `os.environ`.
- Changes affect `rain_lab_meeting.py` and add `rlm-main/rlm-main/dotenv/__init__.py`.

### Testing
- Ran `python -m py_compile rain_lab_meeting.py` and it completed successfully.
- Ran `python rain_lab_meeting.py --help` and it printed the CLI usage successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1db3ebb88332aa6dec4397330f4b)