### PR TITLE
Add optional pyttsx3 Text-to-Speech for meeting agents

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.28.0
 pathlib; python_version<"3.4"
 rich>=13.0.0
 numpy>=1.24.0
+pyttsx3>=2.90


### PR DESCRIPTION
### Motivation
- Provide optional Text-to-Speech playback so agent responses can be heard during meetings while keeping the feature non-blocking and optional.  
- Ensure the meeting continues in text-only mode when the TTS dependency is missing or initialization/playback fails.  

### Description
- Appended `pyttsx3>=2.90` to `requirements.txt` to declare the optional TTS dependency.  
- Added a safe import (`try/except ImportError`) for `pyttsx3` and introduced a lightweight `VoiceEngine` wrapper that initializes `pyttsx3` if available and disables itself on errors.  
- `VoiceEngine.speak()` uses `engine.say(...)` followed by `engine.runAndWait()` to block until playback completes so audio stays synchronized with printed responses.  
- Integrated `VoiceEngine` into `RainLabOrchestrator` (initialize via `self.voice_engine = VoiceEngine()`) and invoked `self.voice_engine.speak(f"{current_agent.name}: {clean_response}")` immediately after printing each agent response.  

### Testing
- Ran `python -m py_compile rain_lab_meeting_chat_version.py` to verify syntax correctness, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699310fa5134832889d0de0342ee97b8)