### PR TITLE
Fix TiDB f-string syntax errors and add missing EOF newlines

### DIFF
--- a/graph_r1_engine/graphr1/__init__.py
+++ b/graph_r1_engine/graphr1/__init__.py
@@ -1,1 +1,2 @@
 from .graphr1 import GraphR1 as GraphR1, QueryParam as QueryParam
+

--- a/graph_r1_engine/graphr1/kg/tidb_impl.py
+++ b/graph_r1_engine/graphr1/kg/tidb_impl.py
@@ -183,7 +183,7 @@ class TiDBKVStorage(BaseKVStorage):
                         "tokens": item["tokens"],
                         "chunk_order_index": item["chunk_order_index"],
                         "full_doc_id": item["full_doc_id"],
-                        "content_vector": f"{item["__vector__"].tolist()}",
+                        "content_vector": f"{item['__vector__'].tolist()}",
                         "workspace": self.db.workspace,
                     }
                 )
@@ -288,7 +288,7 @@ class TiDBVectorDBStorage(BaseVectorStorage):
                         "id": item["id"],
                         "name": item["entity_name"],
                         "content": item["content"],
-                        "content_vector": f"{item["content_vector"].tolist()}",
+                        "content_vector": f"{item['content_vector'].tolist()}",
                         "workspace": self.db.workspace,
                     }
                 )
@@ -304,7 +304,7 @@ class TiDBVectorDBStorage(BaseVectorStorage):
                         "source_name": item["src_id"],
                         "target_name": item["tgt_id"],
                         "content": item["content"],
-                        "content_vector": f"{item["content_vector"].tolist()}",
+                        "content_vector": f"{item['content_vector'].tolist()}",
                         "workspace": self.db.workspace,
                     }
                 )

--- a/graph_r1_engine/graphr1/operate.py
+++ b/graph_r1_engine/graphr1/operate.py
@@ -839,3 +839,4 @@ def combine_contexts(entities, relationships, sources):
     )
 
     return combined_entities, combined_relationships, ""
+

--- a/graph_r1_engine/script_api.py
+++ b/graph_r1_engine/script_api.py
@@ -97,3 +97,4 @@ def search(request: SearchRequest):
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8001)
+


### PR DESCRIPTION
### Motivation
- Fix a critical Python syntax error caused by nested double quotes inside f-strings that crash the build. 
- Resolve Ruff warnings about missing newline at end-of-file to satisfy linter/formatting expectations. 

### Description
- Replace three invalid f-strings in `graph_r1_engine/graphr1/kg/tidb_impl.py` by switching inner dictionary key quotes from `"` to `'` for `__vector__` and two `content_vector` usages. 
- Add a trailing blank line at EOF in `graph_r1_engine/script_api.py`, `graph_r1_engine/graphr1/__init__.py`, and `graph_r1_engine/graphr1/operate.py` to remove "No newline at end of file" warnings. 
- No other functional changes were made. 

### Testing
- Ran `python -m py_compile graph_r1_engine/graphr1/kg/tidb_impl.py graph_r1_engine/script_api.py graph_r1_engine/graphr1/__init__.py graph_r1_engine/graphr1/operate.py` and compilation succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993576354f48328a297f87c30978531)