### PR TITLE
🎨 Palette: Improve input detection UX on non-Windows systems

### DIFF
--- a/rain_lab_meeting_chat_version.py
+++ b/rain_lab_meeting_chat_version.py
@@ -16,6 +16,7 @@ import time
 import uuid
 from pathlib import Path
 import re
+import select
 
 # --- PRE-COMPILED REGEX PATTERNS ---
 RE_QUOTE_DOUBLE = re.compile(r'"([^"]+)"')
@@ -1073,14 +1074,24 @@ class RainLabOrchestrator:
             print(f"\n{current_agent.color}▶ {current_agent.name}'s turn ({current_agent.role})\033[0m")
             print("\033[90m   [Press ENTER to speak, or wait...]\033[0m", end='', flush=True)
             
-            # Windows-compatible: check for keypress during brief window
+            # Cross-platform: check for keypress during brief window
             intervention_window = 1.5  # seconds to wait for user input
             start_time = time.time()
             while time.time() - start_time < intervention_window:
-                if msvcrt and msvcrt.kbhit():  # Check if a key was pressed
+                if msvcrt and msvcrt.kbhit():  # Windows
                     key = msvcrt.getch()
                     user_wants_to_speak = True
                     break
+                elif sys.platform != 'win32':  # Unix/Linux/Mac
+                    try:
+                        r, _, _ = select.select([sys.stdin], [], [], 0)
+                        if r:
+                            sys.stdin.readline()
+                            user_wants_to_speak = True
+                            break
+                    except Exception:
+                        pass
+
                 time.sleep(0.05)  # Small sleep to prevent CPU spinning
             
             print("\r" + " " * 50 + "\r", end='')  # Clear the "Press ENTER" prompt


### PR DESCRIPTION
💡 What: Added cross-platform input detection using `select` on Unix-like systems.
🎯 Why: The previous implementation of the "Press ENTER to speak" intervention only worked on Windows (`msvcrt`), leaving Linux and macOS users unable to interrupt the meeting.
📸 Before/After: Before: Only Windows users could intervene. After: All users can intervene by pressing ENTER.
♿ Accessibility: Ensures the core interaction feature is accessible to users on all supported platforms.

---
*PR created automatically by Jules for task [18443561433286124259](https://jules.google.com/task/18443561433286124259) started by @topherchris420*