### PR TITLE
Prefer chat_with_james in launcher; make CSL extraction robust

### DIFF
--- a/hello_os_executable.py
+++ b/hello_os_executable.py
@@ -75,7 +75,9 @@ def extract_csl_module(output_path: Path = DEFAULT_CSL_MODULE) -> Path:
     head_start = 0
     end_idx = text.find(CSL_END_MARKER, start_idx)
     if end_idx == -1:
-        raise ValueError("Could not locate CSL end marker in hello_os.py")
+        # Package fallback content may not include the flat-file marker.
+        # In that case, extract from the start marker to EOF.
+        end_idx = len(text)
 
     csl_text = text[head_start:end_idx].rstrip() + "\n"
     output_path.write_text(csl_text, encoding="utf-8")

--- a/rain_lab.py
+++ b/rain_lab.py
@@ -130,7 +130,11 @@ def build_command(args: argparse.Namespace, passthrough: list[str], repo_root: P
         cmd.extend(passthrough)
         return cmd
 
-    target = repo_root / "rain_lab_meeting_chat_version.py"
+    # Prefer the dedicated single-agent chat script when present.
+    # Fall back to the legacy meeting chat implementation to preserve compatibility.
+    preferred_target = repo_root / "chat_with_james.py"
+    legacy_target = repo_root / "rain_lab_meeting_chat_version.py"
+    target = preferred_target if preferred_target.exists() else legacy_target
     cmd = [sys.executable, str(target)]
     if args.topic:
         cmd.extend(["--topic", args.topic])

--- a/tests/test_hello_os_executable.py
+++ b/tests/test_hello_os_executable.py
@@ -1,7 +1,7 @@
 import json
 import subprocess
 import sys
-
+import hello_os_executable as hoe
 
 def test_inspect_runs(repo_root):
     """hello_os_executable.py inspect must produce valid JSON."""
@@ -47,3 +47,17 @@ def test_extract_csl(repo_root, tmp_path):
     assert result.returncode == 0, f"extract-csl failed:\n{result.stderr}"
     assert out_file.exists()
     assert out_file.stat().st_size > 0
+
+
+def test_extract_csl_without_end_marker(tmp_path, monkeypatch):
+    """extract-csl should gracefully fall back to EOF when end marker is missing."""
+    sample = "header\nCSL (Cognispheric Symbolic Language)\nbody\n"
+    monkeypatch.setattr(hoe, "_read_hello_os", lambda: sample)
+    out_file = tmp_path / "csl_eof.py"
+
+    out = hoe.extract_csl_module(out_file)
+
+    assert out == out_file
+    content = out_file.read_text(encoding="utf-8")
+    assert "Cognispheric Symbolic Language" in content
+    assert content.endswith("\n")

--- a/tests/test_rain_lab_launcher.py
+++ b/tests/test_rain_lab_launcher.py
@@ -22,7 +22,7 @@ def test_parse_rlm_mode():
 def test_build_command_chat(repo_root):
     args, pt = parse_args(["--mode", "chat", "--topic", "x"])
     cmd = build_command(args, pt, repo_root)
-    assert "rain_lab_meeting_chat_version.py" in cmd[1]
+    assert "chat_with_james.py" in cmd[1]
 
 
 def test_build_command_rlm(repo_root):
@@ -47,3 +47,9 @@ def test_turns_forwarded(repo_root):
     cmd = build_command(args, pt, repo_root)
     assert "--max-turns" in cmd
     assert "5" in cmd
+
+def test_build_command_chat_falls_back_to_legacy(repo_root, monkeypatch):
+    args, pt = parse_args(["--mode", "chat", "--topic", "x"])
+    monkeypatch.setattr(Path, "exists", lambda self: False if self.name == "chat_with_james.py" else Path.__dict__["exists"](self))
+    cmd = build_command(args, pt, repo_root)
+    assert "rain_lab_meeting_chat_version.py" in cmd[1]


### PR DESCRIPTION
### Motivation
- Resolve a launcher mismatch where chat mode defaulted to the legacy script instead of the newer single-agent chat script.
- Prevent brittle failures in `extract-csl` when package-fallback content does not include the flat-file CSL end marker.
- Add tests to lock in the corrected routing and the relaxed extraction behavior.

### Description
- Update `build_command` in `rain_lab.py` to prefer `chat_with_james.py` when present and fall back to `rain_lab_meeting_chat_version.py` for compatibility.
- Modify `extract_csl_module` in `hello_os_executable.py` to treat a missing `CSL_END_MARKER` as EOF and extract through the end of the text instead of raising a `ValueError`.
- Update `tests/test_rain_lab_launcher.py` to assert the preferred `chat_with_james.py` target and add a fallback test that ensures the legacy script is used when the preferred script is absent.
- Add `test_extract_csl_without_end_marker` to `tests/test_hello_os_executable.py` and import the executable module to monkeypatch `_read_hello_os` for reproducing and validating the EOF fallback.

### Testing
- Ran `pytest -q tests/test_rain_lab_launcher.py tests/test_hello_os_executable.py` and all tests passed.
- Result: `12 passed` (tests covering launcher routing, legacy fallback, and CSL extraction EOF fallback succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993ccc06f988328a2203fa9b7129f5c)