### PR TITLE
Improve rain preflight reliability for nested RLM and DuckDuckGo packages

### DIFF
--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -26,3 +26,10 @@ def test_preflight_uses_env_var(repo_root):
     source = (repo_root / "rain_preflight_check.py").read_text(encoding="utf-8")
     assert "JAMES_LIBRARY_PATH" in source
     assert r"C:\Users" not in source
+
+
+def test_preflight_duckduckgo_dual_import_support(repo_root):
+    """Preflight should accept both legacy and current DuckDuckGo import names."""
+    source = (repo_root / "rain_preflight_check.py").read_text(encoding="utf-8")
+    assert '"ddgs"' in source
+    assert '"duckduckgo_search"' in source


### PR DESCRIPTION
### Motivation

- Preflight could falsely fail when `rlm` lived in a nested `rlm-main/rlm-main` layout because it stopped on the first import error. 
- The DuckDuckGo client is published under different import names in the ecosystem, which caused brittle dependency checks. 
- Improve diagnostics so users can more easily see which candidate path succeeded or why import failed.

### Description

- Adjusted `rain_preflight_check.py` to iterate all known `rlm` candidate paths and only fail after all have been tried, while recording and reporting the final import error. 
- When an `rlm` import succeeds, the script now reports the successful candidate path in the output. 
- Reworked the DuckDuckGo dependency check to accept either `ddgs` or `duckduckgo_search` and to print which import name succeeded. 
- Added `tests/test_preflight.py::test_preflight_duckduckgo_dual_import_support` to assert both import names appear in the preflight source.

### Testing

- Ran targeted tests: `pytest -q tests/test_preflight.py tests/test_rain_lab_launcher.py` and both suites passed. 
- Ran full test suite: `pytest -q` which completed with `69 passed, 1 skipped`. 
- Executed `python rain_preflight_check.py` to validate runtime behavior; the script now properly finds nested `rlm` locations and reports DuckDuckGo import status, and it fails only due to LM Studio being unreachable in this environment (expected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994a548f8c4832896d2c47c13a2049f)