### PR TITLE
Add cross-platform OpenClaw background service deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,20 @@ Recursive intellect means each agent can do internal critique+revision passes be
 `hello_os.py` is now treated as a first-class research source for both launcher modes:
 - **RLM mode** exposes `read_hello_os()` so agents can intentionally load and reason over the symbolic/geometric engine.
 - **Chat mode** includes `hello_os.py` in context discovery so agents can cite and use its operator design directly.
+
+
+### Persistent background service (OpenClaw)
+
+To deploy `james_library` as a reboot-persistent background service, run:
+
+```bash
+python deploy.py --service-name james-library --target rain_lab.py --target-args -- --mode chat --topic "autonomous research"
+```
+
+`deploy.py` auto-detects the operating system and installs:
+- Windows: NSSM service command using a headless Python executable (`pythonw.exe` when available)
+- macOS: `~/Library/LaunchAgents/*.plist` with `KeepAlive=true`
+- Linux: `/etc/systemd/system/*.service` with `Restart=always`
+
+The supervisor process is `openclaw_service.py`, which runs a heartbeat every 60 seconds.
+It checks `tasks.json` for `restart` directives and scans `logs/*.log` for crash patterns to self-heal by restarting the target process.

--- a/deploy.py
+++ b/deploy.py
@@ -1,0 +1,157 @@
+"""Cross-platform service installer for james_library OpenClaw supervisor."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+from openclaw_service import pick_headless_python
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Install james_library as a persistent service")
+    parser.add_argument("--service-name", default="james-library")
+    parser.add_argument("--target", default="rain_lab.py", help="Python script managed by OpenClaw")
+    parser.add_argument("--target-args", nargs=argparse.REMAINDER, default=[])
+    parser.add_argument("--dry-run", action="store_true", help="Only print generated files/commands")
+    return parser.parse_args(argv)
+
+
+def _run(cmd: list[str], dry_run: bool) -> None:
+    print("$", " ".join(cmd))
+    if not dry_run:
+        subprocess.run(cmd, check=True)
+
+
+def _windows_install(repo_root: Path, args: argparse.Namespace, dry_run: bool) -> None:
+    wrapper = repo_root / "openclaw_service.py"
+    headless_python = pick_headless_python()
+    clean_target_args = args.target_args[1:] if args.target_args[:1] == ["--"] else args.target_args
+    target_args = ["--", *clean_target_args] if clean_target_args else []
+    nssm_install_cmd = [
+        "nssm",
+        "install",
+        args.service_name,
+        headless_python,
+        str(wrapper),
+        "--service-name",
+        args.service_name,
+        "--target",
+        args.target,
+        *target_args,
+    ]
+    nssm_dir_cmd = ["nssm", "set", args.service_name, "AppDirectory", str(repo_root)]
+    nssm_start_cmd = ["nssm", "start", args.service_name]
+
+    _run(nssm_install_cmd, dry_run)
+    _run(nssm_dir_cmd, dry_run)
+    _run(nssm_start_cmd, dry_run)
+
+
+def _macos_install(repo_root: Path, args: argparse.Namespace, dry_run: bool) -> None:
+    launch_agents = Path.home() / "Library" / "LaunchAgents"
+    launch_agents.mkdir(parents=True, exist_ok=True)
+
+    label = f"com.james_library.{args.service_name}"
+    plist_path = launch_agents / f"{label}.plist"
+    wrapper = repo_root / "openclaw_service.py"
+
+    program_args = [
+        pick_headless_python(),
+        str(wrapper),
+        "--service-name",
+        args.service_name,
+        "--target",
+        args.target,
+    ]
+    clean_target_args = args.target_args[1:] if args.target_args[:1] == ["--"] else args.target_args
+    if clean_target_args:
+        program_args.extend(["--", *clean_target_args])
+
+    args_xml = "\n".join(f"      <string>{arg}</string>" for arg in program_args)
+    plist = f"""<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+  <dict>
+    <key>Label</key>
+    <string>{label}</string>
+    <key>ProgramArguments</key>
+    <array>
+{args_xml}
+    </array>
+    <key>WorkingDirectory</key>
+    <string>{repo_root}</string>
+    <key>KeepAlive</key>
+    <true/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{repo_root / 'logs' / 'openclaw.out.log'}</string>
+    <key>StandardErrorPath</key>
+    <string>{repo_root / 'logs' / 'openclaw.err.log'}</string>
+  </dict>
+</plist>
+"""
+
+    print(f"Writing plist: {plist_path}")
+    if not dry_run:
+        (repo_root / "logs").mkdir(exist_ok=True)
+        plist_path.write_text(plist, encoding="utf-8")
+
+    _run(["launchctl", "unload", str(plist_path)], dry_run)
+    _run(["launchctl", "load", str(plist_path)], dry_run)
+
+
+def _linux_install(repo_root: Path, args: argparse.Namespace, dry_run: bool) -> None:
+    unit_path = Path("/etc/systemd/system") / f"{args.service_name}.service"
+    wrapper = repo_root / "openclaw_service.py"
+    clean_target_args = args.target_args[1:] if args.target_args[:1] == ["--"] else args.target_args
+    target_tail = " -- " + " ".join(clean_target_args) if clean_target_args else ""
+    service_text = f"""[Unit]
+Description=james_library OpenClaw background service
+After=network.target
+
+[Service]
+Type=simple
+User={getpass.getuser()}
+WorkingDirectory={repo_root}
+ExecStart={pick_headless_python()} {wrapper} --service-name {args.service_name} --target {args.target}{target_tail}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+    print(f"Writing systemd unit: {unit_path}")
+    if not dry_run:
+        (repo_root / "logs").mkdir(exist_ok=True)
+        unit_path.write_text(service_text, encoding="utf-8")
+
+    _run(["systemctl", "daemon-reload"], dry_run)
+    _run(["systemctl", "enable", "--now", args.service_name], dry_run)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(__file__).resolve().parent
+    os_name = platform.system().lower()
+
+    print(f"Detected platform: {os_name}")
+    if os_name == "windows":
+        _windows_install(repo_root, args, args.dry_run)
+    elif os_name == "darwin":
+        _macos_install(repo_root, args, args.dry_run)
+    elif os_name == "linux":
+        _linux_install(repo_root, args, args.dry_run)
+    else:
+        raise RuntimeError(f"Unsupported operating system: {platform.system()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/openclaw_service.py
+++ b/openclaw_service.py
@@ -1,0 +1,198 @@
+"""OpenClaw service wrapper and heartbeat monitor for james_library."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+DEFAULT_PATTERNS = [
+    r"traceback",
+    r"fatal",
+    r"segmentation fault",
+    r"unhandled exception",
+    r"out of memory",
+    r"crash",
+]
+
+
+class OpenClawHeartbeat(threading.Thread):
+    """Background monitor that requests service restarts for self-healing."""
+
+    def __init__(
+        self,
+        restart_event: threading.Event,
+        stop_event: threading.Event,
+        interval_s: int = 60,
+        tasks_file: Path | None = None,
+        logs_dir: Path | None = None,
+        patterns: list[str] | None = None,
+    ) -> None:
+        super().__init__(daemon=True, name="openclaw-heartbeat")
+        self.restart_event = restart_event
+        self.stop_event = stop_event
+        self.interval_s = interval_s
+        self.tasks_file = tasks_file or Path("tasks.json")
+        self.logs_dir = logs_dir or Path("logs")
+        self.patterns = [re.compile(p, re.IGNORECASE) for p in (patterns or DEFAULT_PATTERNS)]
+        self._offsets: dict[Path, int] = {}
+
+    def run(self) -> None:
+        while not self.stop_event.is_set():
+            try:
+                if self._has_restart_task() or self._logs_show_crash_pattern():
+                    self.restart_event.set()
+            except Exception as exc:  # pragma: no cover - defensive service loop
+                print(f"[OpenClaw] heartbeat warning: {exc}", flush=True)
+            self.stop_event.wait(self.interval_s)
+
+    def _has_restart_task(self) -> bool:
+        if not self.tasks_file.exists():
+            return False
+
+        with self.tasks_file.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+
+        should_restart = False
+        if isinstance(payload, dict):
+            command = str(payload.get("command", "")).lower().strip()
+            if command in {"restart", "self-heal", "heal"}:
+                should_restart = True
+                payload["command"] = ""
+
+            commands = payload.get("commands")
+            if isinstance(commands, list):
+                for entry in commands:
+                    if isinstance(entry, dict) and str(entry.get("action", "")).lower() == "restart":
+                        should_restart = True
+                        entry["processed"] = True
+
+        if should_restart:
+            with self.tasks_file.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+            print("[OpenClaw] restart task found in tasks.json", flush=True)
+
+        return should_restart
+
+    def _logs_show_crash_pattern(self) -> bool:
+        if not self.logs_dir.exists() or not self.logs_dir.is_dir():
+            return False
+
+        for log_file in sorted(self.logs_dir.glob("*.log")):
+            text = self._read_new_content(log_file)
+            if not text:
+                continue
+            for pattern in self.patterns:
+                if pattern.search(text):
+                    print(
+                        f"[OpenClaw] crash pattern '{pattern.pattern}' found in {log_file}; requesting restart",
+                        flush=True,
+                    )
+                    return True
+        return False
+
+    def _read_new_content(self, file_path: Path) -> str:
+        previous = self._offsets.get(file_path, 0)
+        current_size = file_path.stat().st_size
+        if current_size < previous:
+            previous = 0
+        with file_path.open("r", encoding="utf-8", errors="ignore") as handle:
+            handle.seek(previous)
+            data = handle.read()
+            self._offsets[file_path] = handle.tell()
+        return data
+
+
+def pick_headless_python() -> str:
+    """Prefer a non-console Python executable when available."""
+    if sys.platform.startswith("win"):
+        candidate = Path(sys.executable).with_name("pythonw.exe")
+        if candidate.exists():
+            return str(candidate)
+    if sys.platform == "darwin":
+        candidate = Path(sys.executable).with_name("pythonw")
+        if candidate.exists():
+            return str(candidate)
+    return sys.executable
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="OpenClaw background supervisor for james_library")
+    parser.add_argument("--service-name", default="james-library")
+    parser.add_argument("--target", default="rain_lab.py", help="Python entrypoint to supervise")
+    parser.add_argument("--interval", type=int, default=60, help="Heartbeat interval in seconds")
+    parser.add_argument("target_args", nargs=argparse.REMAINDER, help="Arguments passed to target")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(__file__).resolve().parent
+    target_script = (repo_root / args.target).resolve()
+
+    if not target_script.exists():
+        raise FileNotFoundError(f"Target script not found: {target_script}")
+
+    restart_event = threading.Event()
+    stop_event = threading.Event()
+
+    def _handle_shutdown(signum: int, _frame: object) -> None:
+        print(f"[OpenClaw] received signal {signum}; shutting down", flush=True)
+        stop_event.set()
+
+    signal.signal(signal.SIGTERM, _handle_shutdown)
+    signal.signal(signal.SIGINT, _handle_shutdown)
+
+    heartbeat = OpenClawHeartbeat(
+        restart_event=restart_event,
+        stop_event=stop_event,
+        interval_s=args.interval,
+        tasks_file=repo_root / "tasks.json",
+        logs_dir=repo_root / "logs",
+    )
+    heartbeat.start()
+
+    child: subprocess.Popen[str] | None = None
+    headless_python = pick_headless_python()
+    target_args = list(args.target_args)
+    if target_args and target_args[0] == "--":
+        target_args = target_args[1:]
+
+    while not stop_event.is_set():
+        cmd = [headless_python, str(target_script), *target_args]
+        print(f"[OpenClaw] launching: {' '.join(cmd)}", flush=True)
+        child = subprocess.Popen(cmd, cwd=str(repo_root), env=os.environ.copy())
+
+        while child.poll() is None and not stop_event.is_set():
+            if restart_event.is_set():
+                print("[OpenClaw] self-heal restart requested", flush=True)
+                restart_event.clear()
+                child.terminate()
+                try:
+                    child.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    child.kill()
+                break
+            stop_event.wait(1)
+
+        if stop_event.is_set():
+            if child and child.poll() is None:
+                child.terminate()
+            break
+
+        code = child.returncode if child else 1
+        print(f"[OpenClaw] child exited with code {code}; restarting in 3s", flush=True)
+        time.sleep(3)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_openclaw_service.py
+++ b/tests/test_openclaw_service.py
@@ -1,0 +1,30 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from openclaw_service import OpenClawHeartbeat
+
+
+def test_heartbeat_detects_restart_task(tmp_path):
+    tasks = tmp_path / "tasks.json"
+    tasks.write_text(json.dumps({"command": "restart"}), encoding="utf-8")
+
+    hb = OpenClawHeartbeat(restart_event=None, stop_event=None, tasks_file=tasks)  # type: ignore[arg-type]
+    assert hb._has_restart_task() is True
+    payload = json.loads(tasks.read_text(encoding="utf-8"))
+    assert payload["command"] == ""
+
+
+def test_heartbeat_detects_crash_in_logs(tmp_path):
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    log_file = logs / "app.log"
+    log_file.write_text("all good\n", encoding="utf-8")
+
+    hb = OpenClawHeartbeat(restart_event=None, stop_event=None, logs_dir=logs)  # type: ignore[arg-type]
+    assert hb._logs_show_crash_pattern() is False
+
+    log_file.write_text("all good\nTraceback: boom\n", encoding="utf-8")
+    assert hb._logs_show_crash_pattern() is True


### PR DESCRIPTION
### Motivation

- Provide a cross-platform way to run `james_library` permanently as a background service with automatic self-healing and reboot persistence. 
- Ensure the supervised process runs invisibly with a headless Python executable where available so no terminal window remains open. 
- Add a small, testable supervisor that can detect operator requests (`tasks.json`) and crash patterns in `logs/` to trigger restarts. 

### Description

- Add `deploy.py`, a cross-platform installer that detects the OS via `platform.system()` and installs the supervisor as a persistent service: Windows via NSSM commands, macOS via `~/Library/LaunchAgents/*.plist` with `KeepAlive=true`, and Linux via `/etc/systemd/system/*.service` with `Restart=always`. 
- Add `openclaw_service.py`, a supervisor wrapper that launches the target script (default `rain_lab.py`) under a headless Python (prefers `pythonw.exe`/`pythonw` when present), continuously restarts the child process, and runs an `OpenClawHeartbeat` thread every 60 seconds to request restarts when needed. 
- Heartbeat logic inspects a `tasks.json` file for `restart`/`self-heal` directives and scans `logs/*.log` for common crash patterns (e.g., `traceback`, `fatal`, `segmentation fault`) and records/prints actions when it requests a restart. 
- Update `README.md` with usage for `deploy.py` and add `tests/test_openclaw_service.py` to validate heartbeat behaviors and minor `deploy.py` argument handling improvements for passing `--target-args` through to the supervised process. 

### Testing

- Ran `pytest -q tests/test_openclaw_service.py tests/test_rain_lab_launcher.py` and received `10 passed` (all tests succeeded). 
- Ensured the new modules compile via `python -m py_compile deploy.py openclaw_service.py` which completed successfully. 
- Performed a dry-run installation with `python deploy.py --dry-run --service-name james-library --target rain_lab.py --target-args --mode chat --topic test` which printed the platform-specific actions and (on the test host) displayed the systemd unit/write and service enable commands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69972c6db0a8833288fd780850453ee9)