### PR TITLE
Add GitHub Actions workflow to run pytest on pushes and pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Test Suite
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+
+      - name: Run tests
+        run: pytest -q


### PR DESCRIPTION
### Motivation
- Add CI to run tests on every push and pull request so regressions are caught early by executing the project's test suite automatically.

### Description
- Add `.github/workflows/tests.yml` which triggers on `push` and `pull_request`, checks out the repository, sets up Python `3.11`, installs runtime and dev dependencies (`requirements.txt` and `requirements-dev.txt`), and runs `pytest -q`.

### Testing
- Ran `pytest -q` locally and the suite passed (`76 passed, 1 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69973cc3e68883328fcaf0f2690eec9c)