### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix prompt injection in RLM code execution

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Untrusted content from local files (inbox messages, research papers) was injected directly into the LLM context without sanitization. Attackers could use control tokens (e.g., `<|im_end|>`) or fake headers (e.g., `###`) to hijack the agent's behavior.
 **Learning:** File system inputs are not inherently safe. Any external data entering the prompt must be treated as untrusted, regardless of its source (web or local).
 **Prevention:** Apply a unified sanitization function to ALL external inputs (web search, file reads, user messages) before adding them to the prompt context.
+
+## 2026-02-19 - [Direct Prompt Injection via Code Execution REPL]
+**Vulnerability:** The RLM mode (`rain_lab_meeting.py`) executed tools like `read_paper` and `search_web` inside a REPL without sanitizing their output before returning it to the LLM context. This allowed prompt injection attacks via malicious file content or web results.
+**Learning:** Code execution environments (REPLs) that feed tool outputs back to the LLM are just as vulnerable to indirect prompt injection as standard chat loops. Any function exposed to the REPL that reads external data must sanitize it before returning.
+**Prevention:** Injected a unified `sanitize_text` function into the REPL setup code and wrapped all data-fetching functions (`read_paper`, `search_web`, `read_hello_os`, `semantic_search`) to sanitize their output immediately.


### PR DESCRIPTION
This PR addresses a critical prompt injection vulnerability in the Code Execution (RLM) mode of R.A.I.N. Lab. 

Previously, `rain_lab_meeting.py` read external content (files, web search results) and fed them directly into the LLM context via the REPL. This allowed malicious content (e.g., `<|im_end|>`) to hijack the agent.

This change implements strict output sanitization:
1.  **Global Sanitization:** A `sanitize_text` function strips control tokens (`<|im_start|>`, `###`) and search triggers (`[SEARCH:`).
2.  **REPL Injection:** The sanitization function is injected into the `setup_code` string so it runs inside the agent's Python environment.
3.  **Comprehensive Coverage:** All data ingestion points (`read_paper`, `search_web`, `read_hello_os`, `semantic_search`) now wrap their output with `sanitize_text`.

Verified with a custom regression test suite (`tests/test_input_sanitization_rlm.py` - run locally and deleted) and existing tests.

---
*PR created automatically by Jules for task [6012476988766967629](https://jules.google.com/task/6012476988766967629) started by @topherchris420*