### PR TITLE
Fix missing terminal final output for LM Studio completions

### DIFF
--- a/tests/test_rlm_completion_parsing.py
+++ b/tests/test_rlm_completion_parsing.py
@@ -1,0 +1,34 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "rlm-main" / "rlm-main" / "rlm" / "__init__.py"
+SPEC = importlib.util.spec_from_file_location("rain_local_rlm", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def test_decode_completion_body_standard_json():
+    body = '{"choices":[{"message":{"content":"All good."}}]}'
+    raw, text = MODULE._decode_completion_body(body)
+
+    assert raw["choices"][0]["message"]["content"] == "All good."
+    assert text == "All good."
+
+
+def test_decode_completion_body_sse_dump():
+    body = "\n".join(
+        [
+            'data: {"choices":[{"delta":{"content":"Hello "}}]}',
+            'data: {"choices":[{"delta":{"content":"world"}}]}',
+            "data: [DONE]",
+        ]
+    )
+
+    raw, text = MODULE._decode_completion_body(body)
+
+    assert "_raw_sse" in raw
+    assert text == "Hello world"


### PR DESCRIPTION
### Motivation
- Some local OpenAI-compatible backends (LM Studio) were returning SSE/stream-style payloads or defaulting to streaming, causing callers to see developer logs but never receive a final assistant text in the terminal.  

### Description
- Force non-streamed chat completions by adding `"stream": False` to the payload in the local `RLM` shim at `rlm-main/rlm-main/rlm/__init__.py`.  
- Add robust decoding helpers ` _decode_completion_body`, `_extract_content_from_completion_json`, and `_extract_content_from_sse` to accept either standard JSON completion responses or SSE `data:` frames and reconstruct the final assistant text.  
- Ensure `completion()` returns a stable `(raw, text)` pair so downstream callers always receive the final text even when the backend emits stream-like frames.  
- Add targeted unit tests `tests/test_rlm_completion_parsing.py` that cover both JSON and SSE decoding paths.  

### Testing
- Ran `pytest -q tests/test_rlm_completion_parsing.py`, which passed (`2 passed`).  
- The new tests validate that `_decode_completion_body` handles both standard JSON payloads and SSE-formatted dumps and returns the expected reconstructed text.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69991756ba2883328c373f27990c79f1)