### PR TITLE
Restrict agent sourcing to local research papers and web search

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -50,6 +50,7 @@ RULES:
 - You are ONLY {self.name}. Never speak as another team member.
 - Be concise: 80-120 words max per response.
 - When you need data, write code to get it.
+- Use ONLY research papers from this library (e.g., Coherence Depth, Discrete Celestial Holography, Location is a Dynamic Variable) and web search.
 - Only use: read_paper(), search_web(), list_papers(), search_library(), semantic_search(), visualize_concepts(), generate_mermaid(), remember_entity(), recall_entity()
 """
             self._soul_cache = external_soul + rlm_rules
@@ -70,6 +71,7 @@ RULES:
 RULES:
 - You are ONLY {self.name}. Never speak as another team member.
 - Be concise: 80-120 words max per response.
+- Use ONLY research papers from this library and web search for evidence.
 - Use tools when needed: read_paper(), search_web(), list_papers(), search_library(), semantic_search()
 """
 

--- a/rain_lab_meeting.py
+++ b/rain_lab_meeting.py
@@ -610,6 +610,7 @@ RULES:
 - You are ONLY {self.name}. Never speak as another team member.
 - Be concise: 80-120 words max per response.
 - When you need data, write code to get it.
+- Use ONLY research papers from this library (e.g., Coherence Depth, Discrete Celestial Holography, Location is a Dynamic Variable) and web search.
 - Only use: read_paper(), read_hello_os(), search_web(), list_papers(), search_library(), semantic_search()
 """
             self._soul_cache = external_soul + rlm_rules
@@ -635,6 +636,7 @@ def create_team() -> List[Agent]:
 AVAILABLE: read_paper(), read_hello_os(), run_hello_os_executable(), search_web(), list_papers()
 BANNED: llm_query(), FINAL_VAR(), FINAL(), SHOW_VARS(), context
 RESPOND: 50-100 words, conversational, as a scientist.
+SOURCE RULE: Use only local research papers + web search; do not rely on other sources.
 """
         ),
         Agent(


### PR DESCRIPTION
### Motivation
- Constrain agent evidence gathering so responses are grounded in the project's curated research library (e.g., Coherence Depth, Discrete Celestial Holography, Location is a Dynamic Variable) and corroborating web searches.
- Ensure consistency between runtime meeting prompts and standalone agent personalities so all code paths enforce the same sourcing policy.

### Description
- Added a rule to the RLM prompt block in `agents.py` instructing agents to use only the local research paper library and web search as evidence sources. 
- Updated the fallback/default personality in `agents.py` to include the same source restriction for cases where an external soul file is missing. 
- Mirrored the source restriction in the meeting/runtime prompt in `rain_lab_meeting.py` and added a `SOURCE RULE` line to James's `tool_instruction` to explicitly avoid non-paper/non-web sources. 
- Committed changes to the repository with the message "Restrict agent evidence sources to papers and web search".

### Testing
- Ran `python -m py_compile agents.py rain_lab_meeting.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69991b7564b483329fea1863523903b6)