### PR TITLE
Fix README video visibility on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 ## 🚀 open-source (beta) R.A.I.N. Lab
 
-<video src="assets/logo.mp4" controls width="720">
-</video>
+[![Watch the R.A.I.N. Lab intro video](assets/james-library.svg)](assets/logo.mp4)
 
-![James Library](assets/james-library.svg)
+_Click the image above to open the intro video (`assets/logo.mp4`)._
 
 R.A.I.N. Lab (Recursive Architecture of Intelligent Nexus) is open source.
 


### PR DESCRIPTION
### Motivation
- GitHub does not reliably render HTML `<video>` embeds in README files, which hid the project intro video from viewers.

### Description
- Replace the inline `<video>` element with a Markdown-linked thumbnail `[![Watch the R.A.I.N. Lab intro video](assets/james-library.svg)](assets/logo.mp4)` and add a brief instructional line `_Click the image above to open the intro video (`assets/logo.mp4`)._`.

### Testing
- Inspected the updated `README.md` with `nl -ba README.md | sed -n '1,30p'` to confirm the new link and explanatory note are present and verified that `assets/james-library.svg` and `assets/logo.mp4` are referenced correctly; checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e133e95c8332881771730b6551fc)