### PR TITLE
fix(build): add missing agent benchmark target

### DIFF
--- a/benches/agent_benchmarks.rs
+++ b/benches/agent_benchmarks.rs
@@ -1,0 +1,12 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn benchmark_noop(c: &mut Criterion) {
+    c.bench_function("noop", |b| {
+        b.iter(|| {
+            black_box(42_u64);
+        })
+    });
+}
+
+criterion_group!(benches, benchmark_noop);
+criterion_main!(benches);


### PR DESCRIPTION
### Motivation
- Cargo manifest declared a `[[bench]]` named `agent_benchmarks` but the corresponding source file was missing, causing `cargo test` to fail at manifest parsing.

### Description
- Add `benches/agent_benchmarks.rs` containing a minimal Criterion benchmark (`benchmark_noop`) and the `criterion_group!`/`criterion_main!` entrypoints so the bench target referenced in `Cargo.toml` resolves to an existing source file.

### Testing
- Ran `cargo test` to validate manifest parsing; manifest parsing now succeeds but full test execution is blocked by crates.io connectivity errors (HTTP 403) in this environment. (failure due to network, not the change)
- Ran `rustfmt --check benches/agent_benchmarks.rs` which succeeded.
- Ran `cargo fmt --all -- --check` which failed due to unrelated formatting drift in `src/peripherals/mod.rs` (pre-existing and not modified by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f525bc0083289f01152d03c7de9a)