### PR TITLE
feat(agent): bounded self-improvement with human-gated change requests

### DIFF
--- a/docs/BOUNDED_ADAPTATION_POLICY.md
+++ b/docs/BOUNDED_ADAPTATION_POLICY.md
@@ -1,0 +1,41 @@
+# Bounded Agent Adaptation Policy
+
+## Behavior Scope
+
+The runtime allows bounded self-improvement in three surfaces only:
+
+- **Memory adaptation**: context retrieval now prefers explicit memory cues (for example `remember`, `earlier`, `previous`) and uses bounded summarization for recalled entries.
+- **Routing adaptation**: per-message model routing honors explicit classification signals and resolves to configured `hint:<route>` when the hint exists in model routes.
+- **Tool strategy adaptation**: tool execution uses strict bounds (iteration budget, per-call timeout, bounded retries with deterministic backoff).
+
+## Hard Safety Limits
+
+- Maximum tool-loop iterations are still bounded by `agent.max_tool_iterations`.
+- Tool calls have a fixed timeout and bounded retry budget.
+- Retry behavior is deterministic and finite.
+- Tool failures are explicit (no silent fallback broadening permissions).
+- Tool outputs are credential-scrubbed before returning to the model history/logging path.
+
+## Forbidden Autonomous Mutations
+
+The agent does **not** autonomously apply runtime/policy/config/code mutations on restricted paths.
+
+When a tool call proposes a restricted mutation (for example editing `src/*.rs`, config/policy-like targets, or runtime config mutators), execution is blocked and a structured **change request artifact** is emitted in the tool result payload.
+
+## Human Approval Flow
+
+1. Agent proposes a structured change request artifact.
+2. Artifact includes: request type, reason, target, tool/arguments proposal, and `requires_human_approval=true`.
+3. No mutation is executed automatically.
+4. Operator reviews and explicitly approves out-of-band before any real mutation command is run.
+
+## Rollback Notes
+
+If this behavior must be rolled back quickly, revert the commit that introduced bounded adaptation guards in `src/agent/loop_.rs` and this document.
+
+Expected rollback effect:
+
+- Removes explicit change-request blocking logic for restricted tool calls.
+- Restores prior memory/context shaping behavior.
+- Restores prior tool timeout/retry behavior.
+


### PR DESCRIPTION
### Motivation

- Constrain agent self-improvement so adaptation is limited to memory, routing, and tool strategy while preventing autonomous edits to runtime/policy/config/code. 
- Provide deterministic fail-fast safety (timeouts, bounded retries, iteration caps) to avoid runaway tool loops and reduce blast radius. 
- Make any proposal to change runtime/policy/config a structured, reviewable artifact that requires explicit human approval. 

### Description

- Added bounded tool execution policy in the agent loop by introducing per-call timeout, bounded retry budget, and deterministic exponential backoff (`DEFAULT_TOOL_CALL_TIMEOUT`, `TOOL_RETRY_LIMIT`, `TOOL_RETRY_BASE_BACKOFF_MS`) and incorporated these into `execute_one_tool` with structured failure outcomes. (Changes in `src/agent/loop_.rs`.)
- Implemented memory-adaptation heuristics that (a) detect explicit memory recall signals in user messages, (b) increase recall limits and relax relevance thresholds only when signaled, and (c) truncate/summarize recalled entries to a safe char limit (`MAX_MEMORY_RECALL_ENTRIES`, `DEFAULT_MEMORY_RECALL_ENTRIES`, `MEMORY_ENTRY_MAX_CHARS`). (Changes in `src/agent/loop_.rs`.)
- Added per-message routing adaptation: `effective_model_for_message` uses configured query-classification rules to map to `hint:<route>` only when the route exists, and this is used in one-shot and interactive flows. (Changes in `src/agent/loop_.rs`.)
- Enforced the human gate for forbidden autonomous mutations by detecting restricted tool targets (for example edits affecting `src/*.rs`, `.toml`, or config/policy-like paths) and blocking execution; instead the agent emits a structured `ChangeRequestArtifact` (JSON payload) in the tool-result area indicating `requires_human_approval: true`. No code/config mutations are applied automatically. (Changes in `src/agent/loop_.rs`.)
- Added unit tests that exercise the new behaviors: memory-signal recall, classification-driven routing, tool retry/backoff and timeout enforcement, loop iteration-cap fast-fail, and blocked restricted self-edit producing a change-request artifact. (Tests added inline in `src/agent/loop_.rs` test module.)
- Added documentation `docs/BOUNDED_ADAPTATION_POLICY.md` describing scope, hard safety limits, forbidden paths, human approval flow, and rollback notes.

### Testing

- Ran formatting check: `cargo fmt --all -- --check` — succeeded.
- Ran lints: `cargo clippy --all-targets -- -D warnings` — failed due to pre-existing repository/environment issues unrelated to this change (examples: missing embedded web assets `web/dist/` referenced by `rust-embed` in `src/gateway/static_files.rs`, other unrelated clippy/compile warnings in other crates/modules). The new code is formatted and clippy warnings introduced by this patch were addressed where applicable; remaining clippy failures are in files outside the patch scope.
- Ran test compile: `cargo test` — could not complete due to the same pre-existing compile errors in the repository (the `rust-embed` folder missing and other unrelated compilation failures). Because these failures are outside the touched `src/agent/loop_.rs` scope, the added unit tests could not be executed in CI here.

Exact commands run and short results:
- `cargo fmt --all -- --check` — OK
- `cargo clippy --all-targets -- -D warnings` — FAILED (repo has unrelated issues; see `src/gateway/static_files.rs` rust-embed asset and other pre-existing warnings)
- `cargo test` — BLOCKED (compile errors due to repository state unrelated to this PR)

Skipped/blocked checks reason: several compile/lint failures originate from existing repository state (missing `web/dist/` asset for `RustEmbed` and other unrelated clippy errors in untouched modules) which prevented running the newly added tests; these are not caused by the changes in this PR and should be resolved separately in the repo environment or in a follow-up housekeeping PR.

If reviewers want a narrower rollback, revert the edits in `src/agent/loop_.rs` and remove `docs/BOUNDED_ADAPTATION_POLICY.md` to restore prior behavior; no factory/trait APIs were modified so rollback is straightforward and reversible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a195de685c8328bb02df88dd76ab6f)