### PR TITLE
fix(gateway): add embedded dashboard placeholder asset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ target/
 # Jupyter
 .ipynb_checkpoints/
 >>>>>>> 1145494aa9240155d5d88fdd62050cd53c475cab
+
+# Embedded dashboard fallback assets
+!web/dist/
+!web/dist/index.html

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZeroClaw Dashboard</title>
+  </head>
+  <body>
+    <main>
+      <h1>ZeroClaw Dashboard Assets Not Built</h1>
+      <p>
+        This placeholder page is embedded so Rust builds and tests can run in environments
+        where the frontend bundle has not been generated yet.
+      </p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Ensure `rust-embed` has a real `web/dist/` directory at compile time so builds/tests do not fail in environments where the frontend bundle has not been generated.

### Description
- Add a tracked placeholder file at `web/dist/index.html` and update `.gitignore` to unignore `web/dist/` and `web/dist/index.html` so the embedded-assets path used by `#[derive(Embed)]` is present.

### Testing
- Ran `cargo check --lib` which completed successfully after the change, whereas `cargo test` previously failed due to the missing embedded asset directory and `rust-embed` compile error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a45181a4e883248e8eb841b4fcf619)