### PR TITLE
fix(runtime): gate Windows-only `OsString` imports

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -10,6 +10,7 @@ use crate::security::SecurityPolicy;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use futures_util::{stream, StreamExt};
+#[cfg(windows)]
 use std::ffi::OsString;
 use std::path::Path;
 use std::process::Stdio;
@@ -593,7 +594,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut config = test_config(&tmp).await;
         config.autonomy.allowed_commands = vec![missing_path_allowed_command().into()];
-        let job = test_job(&missing_path_command("definitely_missing_file_for_scheduler_test"));
+        let job = test_job(&missing_path_command(
+            "definitely_missing_file_for_scheduler_test",
+        ));
         let security = SecurityPolicy::from_config(&config.autonomy, &config.workspace_dir);
 
         let (success, output) = run_job_command(&config, &security, &job).await;

--- a/src/runtime/native.rs
+++ b/src/runtime/native.rs
@@ -1,4 +1,5 @@
 use super::traits::RuntimeAdapter;
+#[cfg(windows)]
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 

--- a/src/tunnel/custom.rs
+++ b/src/tunnel/custom.rs
@@ -1,5 +1,6 @@
 use super::{kill_shared, new_shared_process, SharedProcess, Tunnel, TunnelProcess};
 use anyhow::{bail, Result};
+#[cfg(windows)]
 use std::ffi::OsString;
 use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;


### PR DESCRIPTION
### Motivation

- Non-Windows builds emitted `unused import: std::ffi::OsString` warnings because `OsString` is only referenced inside `#[cfg(windows)]` command-construction blocks, so the import must be platform-gated.

### Description

- Make the `OsString` import conditional with `#[cfg(windows)]` in `src/runtime/native.rs` to avoid unused-import warnings on Unix-like platforms.
- Make the `OsString` import conditional with `#[cfg(windows)]` in `src/tunnel/custom.rs` to keep Windows-specific shell command construction working while removing warnings elsewhere.
- Make the `OsString` import conditional with `#[cfg(windows)]` in `src/cron/scheduler.rs` for the scheduler's Windows command branches.
- Run `cargo fmt` which formatted a few test-line breaks as part of normalization.

### Testing

- Ran `cargo fmt --all -- --check` and it passed successfully.
- Ran `cargo test` to reproduce and validate the prior unused-import warning scenario during compilation and to exercise scheduler/runtime paths, which confirmed the warning before the fix and no new warnings after the change.
- Attempted `cargo clippy --all-targets -- -D warnings` but the run was interrupted by long-running cargo lock/contention in the environment and could not complete to final success in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a456eafcd88324b793c8c1d26ec45b)