### PR TITLE
Initialize RainLabConfig in config and onboarding; remove unused OsString imports

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -3668,6 +3668,7 @@ impl Default for Config {
             hardware: HardwareConfig::default(),
             query_classification: QueryClassificationConfig::default(),
             transcription: TranscriptionConfig::default(),
+            rain_lab: RainLabConfig::default(),
         }
     }
 }
@@ -5210,6 +5211,7 @@ default_temperature = 0.7
             hooks: HooksConfig::default(),
             hardware: HardwareConfig::default(),
             transcription: TranscriptionConfig::default(),
+            rain_lab: RainLabConfig::default(),
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -5392,6 +5394,7 @@ tool_dispatcher = "xml"
             hooks: HooksConfig::default(),
             hardware: HardwareConfig::default(),
             transcription: TranscriptionConfig::default(),
+            rain_lab: RainLabConfig::default(),
         };
 
         config.save().await.unwrap();

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -10,7 +10,6 @@ use crate::security::SecurityPolicy;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use futures_util::{stream, StreamExt};
-use std::ffi::OsString;
 use std::path::Path;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -593,7 +592,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut config = test_config(&tmp).await;
         config.autonomy.allowed_commands = vec![missing_path_allowed_command().into()];
-        let job = test_job(&missing_path_command("definitely_missing_file_for_scheduler_test"));
+        let job = test_job(&missing_path_command(
+            "definitely_missing_file_for_scheduler_test",
+        ));
         let security = SecurityPolicy::from_config(&config.autonomy, &config.workspace_dir);
 
         let (success, output) = run_job_command(&config, &security, &job).await;

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -169,6 +169,7 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
         hardware: hardware_config,
         query_classification: crate::config::QueryClassificationConfig::default(),
         transcription: crate::config::TranscriptionConfig::default(),
+        rain_lab: crate::config::schema::RainLabConfig::default(),
     };
 
     println!(
@@ -520,6 +521,7 @@ async fn run_quick_setup_with_home(
         hardware: crate::config::HardwareConfig::default(),
         query_classification: crate::config::QueryClassificationConfig::default(),
         transcription: crate::config::TranscriptionConfig::default(),
+        rain_lab: crate::config::schema::RainLabConfig::default(),
     };
 
     config.save().await?;

--- a/src/runtime/native.rs
+++ b/src/runtime/native.rs
@@ -1,5 +1,4 @@
 use super::traits::RuntimeAdapter;
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 /// Native runtime — full access, runs on Mac/Linux/Docker/Raspberry Pi

--- a/src/tunnel/custom.rs
+++ b/src/tunnel/custom.rs
@@ -1,6 +1,5 @@
 use super::{kill_shared, new_shared_process, SharedProcess, Tunnel, TunnelProcess};
 use anyhow::{bail, Result};
-use std::ffi::OsString;
 use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;
 


### PR DESCRIPTION
### Motivation

- Initialize a newly introduced `RainLabConfig` so the global `Config` and onboarding flows include the new feature by default.
- Eliminate unused `std::ffi::OsString` imports to silence warnings and keep code tidy.

### Description

- Add `rain_lab: RainLabConfig::default()` to the `Config` default construction and to places building default `Config` instances used in tests and persistence.
- Initialize `rain_lab` in onboarding flows by setting `rain_lab: crate::config::schema::RainLabConfig::default()` in `run_wizard` and `run_quick_setup_with_home`.
- Remove unused `std::ffi::OsString` imports from `cron/scheduler.rs`, `runtime/native.rs`, and `tunnel/custom.rs`.
- Apply a minor formatting tweak to a multi-line test string invocation in `cron/scheduler.rs` for clarity.

### Testing

- Ran the test suite with `cargo test` which executed unit and async `tokio` tests, and the tests completed successfully.
- Performed a `cargo build` to ensure the project compiles cleanly after the changes and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7bb2648fc83249e2b312fc6e69883)