### PR TITLE
fix(doctor): normalize scheme-less base URLs

### DIFF
--- a/rain_lab_chat/doctor.py
+++ b/rain_lab_chat/doctor.py
@@ -12,9 +12,9 @@ except ImportError:
 
 def models_endpoint_from_base_url(base_url: str) -> str:
     raw = (base_url or "").strip() or "http://127.0.0.1:1234/v1"
+    if "://" not in raw:
+        raw = f"http://{raw}"
     parsed = urlparse(raw)
-    if not parsed.scheme:
-        parsed = urlparse(f"http://{raw}")
 
     scheme = parsed.scheme or "http"
     netloc = parsed.netloc


### PR DESCRIPTION
### Motivation
- Fix a CI failure where `models_endpoint_from_base_url` mis-parsed inputs like `127.0.0.1:1234/v1` because `urlparse` treats text without `://` as a scheme, causing incorrect `/v1/models` construction.

### Description
- Prepend `http://` to scheme-less `base_url` inputs before calling `urlparse` in `rain_lab_chat/doctor.py`, ensuring the host/port land in `netloc` and the returned models endpoint is correct.

### Testing
- Ran `ruff check . --output-format=full` and `pytest tests/test_rain_doctor.py -v` (3 passed) and then the full test suite with `pytest tests/ -v -ra --tb=long`, which resulted in `199 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa26422b088332a3a5ecf36b1aa2e3)