### PR TITLE
GitHub Actions: add `dev` branch to CI triggers and remove PR trigger from Test Suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ permissions:
   contents: read
 on:
   push:
-    branches: [main]
+    branches: [dev, main]
   pull_request:
-    branches: [main]
+    branches: [dev, main]
 
 jobs:
   lint-and-test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - '**'
-  pull_request:
 
 jobs:
   tests:


### PR DESCRIPTION
### Motivation
- Enable CI runs for the `dev` branch and simplify the Test Suite triggers by removing `pull_request` handling so tests run on pushes only.

### Description
- Updated `.github/workflows/ci.yml` to include `dev` alongside `main` for both `push` and `pull_request` triggers, and removed the `pull_request` trigger from `.github/workflows/tests.yml` so `tests.yml` runs only on `push` to all branches.

### Testing
- No automated tests were executed as part of this PR because the change only modifies CI workflow configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0cea4bd448332852f99f2d8d77a33)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
