### PR TITLE
fix(ci): guard module-level _init_rag() with RAIN_SKIP_RAG; add ruff …

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,5 +35,8 @@ jobs:
             pip install -r requirements-dev.txt
           fi
 
+      - name: Lint (ruff)
+        run: python -m ruff check . --select E,F,W,I
+
       - name: Run tests
         run: pytest -q

--- a/external_integrations.py
+++ b/external_integrations.py
@@ -6,7 +6,6 @@ Tools for ArXiv, DOI lookup, BibTeX generation, and Context Hub (API documentati
 
 import json
 import re
-import subprocess
 import urllib.parse
 import urllib.request
 

--- a/rain_lab_meeting.py
+++ b/rain_lab_meeting.py
@@ -569,17 +569,19 @@ def SHOW_VARS(*args, **kwargs):
 
 # Initialize on startup (best effort)
 REQUIRE_WEB = os.environ.get("RLM_REQUIRE_WEB", "1") == "1"
+SKIP_RAG = os.environ.get("RAIN_SKIP_RAG", "0") == "1"
 try:
     if REQUIRE_WEB:
         _require_web_search()
-    _init_rag()
+    if not SKIP_RAG:
+        _init_rag()
 except BaseException as e:
     print(f"[ERROR] Setup initialization failed: {e}")
 
 # Trigger one-time index if possible?
 # For now, we trust the agent or user to call index_library() if needed, 
 # OR we just do a quick check.
-if collection and collection.count() == 0:
+if not SKIP_RAG and collection and collection.count() == 0:
     print("Empty library detected. Indexing now...")
     index_library()
 '''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,11 @@
+import os
+
+# Guard against tools.py module-level _init_rag() loading torch/sentence_transformers
+# during test collection, which causes a Windows access violation and kills pytest.
+# These must be set before any import of tools, rain_lab_meeting, etc.
+os.environ.setdefault("RAIN_SKIP_RAG", "1")
+os.environ.setdefault("RLM_REQUIRE_WEB", "0")
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_integration_flow.py
+++ b/tests/test_integration_flow.py
@@ -1,8 +1,11 @@
 import os
-from unittest.mock import MagicMock, patch
 
-# Ensure we're targeting the papers directory for the mock setup
+# Set env vars BEFORE any other imports so _init_rag() is never triggered
+# by the module-level tools.py init block or the RLM setup_code execution.
 os.environ["RLM_REQUIRE_WEB"] = "0"
+os.environ["RAIN_SKIP_RAG"] = "1"
+
+from unittest.mock import MagicMock, patch
 
 from rain_lab_meeting import ResearchCouncil
 from tools import get_setup_code

--- a/tools.py
+++ b/tools.py
@@ -1162,18 +1162,18 @@ def SHOW_VARS(*args, **kwargs):
     raise NameError("SHOW_VARS does not exist! Use print() instead.")
 
 # Initialize on startup (best effort)
+# Set RAIN_SKIP_RAG=1 to suppress auto-init (e.g. during tests or lightweight imports).
 REQUIRE_WEB = os.environ.get("RLM_REQUIRE_WEB", "1") == "1"
+SKIP_RAG = os.environ.get("RAIN_SKIP_RAG", "0") == "1"
 try:
     if REQUIRE_WEB:
         _require_web_search()
-    _init_rag()
+    if not SKIP_RAG:
+        _init_rag()
 except BaseException as e:
     print(f"[ERROR] Setup initialization failed: {e}")
 
-# Trigger one-time index if possible?
-# For now, we trust the agent or user to call index_library() if needed,
-# OR we just do a quick check.
-if collection and collection.count() == 0:
+if not SKIP_RAG and collection and collection.count() == 0:
     print("Empty library detected. Indexing now...")
     index_library()
 


### PR DESCRIPTION
…lint step

Importing tools.py triggered an unconditional _init_rag() call at module load time, which imported sentence_transformers → torch and caused a Windows access violation that killed the entire pytest process.

Changes:
- tools.py: skip _init_rag() and auto-index when RAIN_SKIP_RAG=1
- rain_lab_meeting.py: same guard in the embedded _DEFAULT_SETUP_CODE
- tests/conftest.py: set RAIN_SKIP_RAG=1 + RLM_REQUIRE_WEB=0 before any test imports to prevent the crash during collection
- tests/test_integration_flow.py: move env var setup above all imports
- external_integrations.py: remove unused subprocess import (F401)
- .github/workflows/tests.yml: add ruff lint step before pytest

Before: test collection aborted with Windows fatal exception (access violation in torch._load_dll_libraries); test_context_hub.py and test_integration_flow.py never ran.
After: ruff check exits 0; 18/18 targeted tests pass in ~7s.

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion):
- Problem:
- Why it matters:
- What changed:
- What did **not** change (scope boundary):

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`):
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Mitigation:

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
