### PR TITLE
Add low-friction contributor onboarding and fast-path guidance to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,3 +94,42 @@ pytest tests/ -v
 # Lint
 ruff check .
 ```
+
+## Contributor Onboarding (Low-Friction Path)
+
+If this is your first PR, pick one lane and keep scope small:
+
+1. **Docs lane (fastest)**
+   - Good first files: `README.md`, `docs/FIRST_RUN_CHECKLIST.md`, `docs/TROUBLESHOOTING.md`
+   - Validation: preview markdown + run any link checks you use locally
+2. **Python lane**
+   - Good first files: `rain_lab.py`, `hello_os/core.py`, `hello_os/utils.py`
+   - Validation: `ruff check .` and `pytest tests/ -q`
+3. **Rust lane**
+   - Good first files: `src/main.rs`, `src/providers/`, `src/tools/`
+   - Validation:
+     - `cargo fmt --all -- --check`
+     - `cargo clippy --all-targets -- -D warnings`
+     - `cargo test`
+
+### Practical discoverability commands
+
+Use these to find the right edit target before changing code:
+
+```bash
+# Locate launcher mode handling
+rg "--mode|mode" rain_lab.py hello_os src/main.rs
+
+# Locate provider/tool extension points
+rg "Provider|Tool|factory|register" src/providers src/tools src/main.rs
+
+# Locate tests near the code you changed
+rg "pytest|#[ ]*test|mod tests" tests src
+```
+
+### PR checklist (first-time friendly)
+
+- [ ] Keep the PR focused on one concern
+- [ ] Run the smallest relevant validation set for the files you touched
+- [ ] Describe what changed, why, and any non-goals
+- [ ] Note rollback strategy for behavior-changing patches

--- a/README.md
+++ b/README.md
@@ -184,6 +184,56 @@ python rain_lab.py --mode onboard
 python rain_lab.py --mode gateway
 ```
 
+### Contributor Fast Path (30-Minute Onboarding)
+
+If you want to contribute quickly without learning every subsystem first, use this path:
+
+```bash
+git clone https://github.com/topherchris420/james_library.git
+cd james_library
+
+# Python-first setup for docs/tests and launcher checks
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+
+# Baseline checks most small PRs should run
+ruff check .
+pytest tests/ -q
+```
+
+Then choose one entry point:
+
+- Docs/navigation improvements: edit `README.md`, `CONTRIBUTING.md`, or files under `docs/`.
+- Python launcher flow: start in `rain_lab.py` and related modules in `hello_os/`.
+- Rust runtime integration: start in `src/main.rs`, then trace into `src/agent/`, `src/providers/`, and `src/tools/`.
+
+Before opening a PR, run the checks relevant to your change and include command output in the PR description.
+
+### First Contribution Map (Practical Discoverability)
+
+Use this map to avoid "where do I start?" friction:
+
+| Goal | Best first file(s) | Why this is a good starting point |
+|---|---|---|
+| Improve onboarding docs | `README.md`, `docs/FIRST_RUN_CHECKLIST.md`, `CONTRIBUTING.md` | High visibility and low risk |
+| Add/adjust launcher behavior | `rain_lab.py`, `hello_os/core.py` | Fast feedback loop from CLI modes |
+| Improve troubleshooting guidance | `docs/TROUBLESHOOTING.md`, `docs/PRODUCTION_READINESS.md` | Direct user impact, easy to validate |
+| Work on provider/tool runtime behavior | `src/providers/`, `src/tools/`, `src/agent/` | Core multi-agent orchestration paths |
+
+Recommended discovery commands:
+
+```bash
+# Find mode entry points and command handlers
+rg "--mode|mode" rain_lab.py hello_os src/main.rs
+
+# Find where providers/tools are wired
+rg "mod providers|mod tools|factory|Provider|Tool" src
+
+# Find tests close to touched code
+rg "pytest|#[ ]*test|mod tests" tests src
+```
+
 ---
 
 ## Download Binaries


### PR DESCRIPTION
### Motivation

- Lower initial contribution friction by providing a concise, explicit onboarding path for first-time contributors. 
- Make it easier to discover relevant code areas and validation commands so small, focused PRs can be submitted quickly. 
- Improve visibility of simple checks and a checklist to reduce back-and-forth on trivial PRs.

### Description

- Added a "Contributor Onboarding (Low-Friction Path)" section to `CONTRIBUTING.md` with three suggested lanes (Docs, Python, Rust), validation commands, practical `rg` discovery snippets, and a first-time PR checklist. 
- Extended `README.md` with a "Contributor Fast Path (30-Minute Onboarding)" section showing a minimal local setup, baseline checks, recommended entry points, and a "First Contribution Map" table for discoverability. 
- Included concrete commands to run common linters and test targets (`ruff`, `pytest`, `cargo fmt`, `cargo clippy`, `cargo test`) and guidance on what files are good first edits.

### Testing

- Ran `ruff check .` as a baseline linter check and it completed successfully. 
- Ran `pytest tests/ -q` to validate the test suite and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2aede4f2c8324a071cdcd16ac3827)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
