### PR TITLE
docs(onboarding): simplify entry point and clarify non-technical onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ powershell -ExecutionPolicy Bypass -File .\scripts\quickstart_lmstudio.ps1
 
 That is enough to get a working first experience.
 
+### For Non-Technical Users: One Safe Entry Point
+
+Use only:
+
+```bash
+python rain_lab.py
+```
+
+You can ignore most other top-level scripts unless a maintainer asks you to run one directly.
+
 ---
 
 ## What to run next

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -6,6 +6,62 @@
 
 ---
 
+## If You Only Read One Thing
+
+Use this command:
+
+```bash
+python rain_lab.py
+```
+
+For non-technical users, this is the **only entry point you need**. The script includes a guided wizard, first-run setup, validation checks, model listing, and chat/research modes.
+
+You can safely ignore files like `rain_unique.py`, `james_reader.py`, `chat_with_james.py`, and other specialized scripts unless a maintainer tells you to use them.
+
+---
+
+## Name Guide (Plain English)
+
+- **R.A.I.N. Lab**: the product experience you use.
+- **ZeroClaw**: the Rust runtime engine under the hood.
+- **James Library**: the Python workflow collection in this repository.
+- **Vers3Dynamics**: the project/organization branding.
+
+If you're just using the tool, think of all of this as one app and start with `python rain_lab.py`.
+
+---
+
+
+## Prerequisites (Simple Checklist)
+
+Before first use, install:
+
+1. **Python 3.10+**
+2. **Ollama**
+3. At least one model (example):
+   ```bash
+   ollama pull qwen2.5-coder
+   ```
+
+If you are unsure whether setup is complete, run:
+
+```bash
+python rain_lab.py --mode validate
+```
+
+---
+
+## First-Time Onboarding Flow
+
+For a new non-technical user:
+
+1. Install Python and Ollama.
+2. Run `python rain_lab.py --mode first-run` once.
+3. Run `python rain_lab.py` and choose **Chat** or **Guided mode**.
+4. If anything fails, run `python rain_lab.py --mode validate`.
+
+---
+
 ## One Command to Start
 
 ### Any System (Recommended)


### PR DESCRIPTION
### Motivation

- Reduce confusion for non-technical users caused by multiple top-level entry scripts and unclear naming.
- Provide one clear, safe starting command so newcomers don't need to decide between multiple specialized scripts.
- Make prerequisites and first-run steps explicit to reduce setup friction and failed starts.

### Description

- Added an "If You Only Read One Thing" section to `START_HERE.md` that directs non-technical users to run `python rain_lab.py` and explains that other scripts can be ignored unless requested by a maintainer. 
- Added a plain-language name guide to `START_HERE.md` that maps product/tech terms (R.A.I.N. Lab, ZeroClaw, James Library, Vers3Dynamics) to simple roles. 
- Added a concise prerequisites checklist and a step-by-step first-time onboarding flow to `START_HERE.md` to guide new users through `first-run` and `validate` flows. 
- Added a "For Non-Technical Users: One Safe Entry Point" section to `README.md` reinforcing `python rain_lab.py` as the recommended top-level command; no runtime, CLI flag, or installer code was changed.

### Testing

- Performed markdown inspections and file previews to confirm new sections and code snippets were inserted and render as intended. 
- Validated that referenced launcher modes (`first-run`, `validate`, `models`, `chat`, `rlm`) still match the existing CLI usage documented in the repository. 
- No compilation or unit tests were required because this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b446c6be4c8332adc14b4928cce443)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
