### PR TITLE
fix(rain-lab): restore chat as default launcher mode

### DIFF
--- a/rain_lab.py
+++ b/rain_lab.py
@@ -166,7 +166,7 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     parser.add_argument(
         "--mode",
         choices=["rlm", "chat", "godot", "hello-os", "compile", "preflight", "backup", "first-run", "wizard", "start", "validate", "models", "onboard", "status"],
-        default="wizard",
+        default="chat",
         help="Which engine to run: wizard (guided help), start (same as wizard), chat (talk to AI), validate (check system), models (list AI models), status (show status), onboard (first-time setup), rlm (tool-exec), godot (chat + visual), hello-os (executable), compile (build knowledge), preflight (env checks), backup (snapshot), first-run (onboarding)",
     )
     parser.add_argument("--topic", type=str, default=None, help="Meeting topic")


### PR DESCRIPTION
### Motivation
- No-argument launcher invocations and the unit test expected `chat` as the default, but the parser was defaulting to `wizard`, causing a test failure and surprising behavior.

### Description
- Change the `--mode` argument default in `rain_lab.py` from `"wizard"` to `"chat"` so no-arg launches match the expected chat behavior.

### Testing
- Ran `pytest -q tests/test_rain_lab_launcher.py::test_parse_defaults` which passed, and ran the full test suite with `pytest -q` which completed with `154 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44ece59888332b3c798907fc64ac3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
