### PR TITLE
Add P2P gossip publishing for advisory results (libp2p gossipsub + kademlia)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ which = "8.0"
 # WebSocket client channels (Discord/Lark/DingTalk/Nostr)
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
-libp2p = { version = "0.55", default-features = false, features = ["tokio", "tcp", "noise", "yamux", "gossipsub", "kad", "macros"] }
+libp2p = { version = "0.55", default-features = false, features = ["tokio", "tcp", "noise", "yamux", "gossipsub", "kad", "macros"], optional = true }
 nostr-sdk = { version = "0.44", default-features = false, features = ["nip04", "nip59"] }
 regex = "1.10"
 hostname = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clap_complete = "4.5"
 tokio = { version = "1.42", default-features = false, features = ["rt-multi-thread", "macros", "time", "net", "io-util", "sync", "process", "io-std", "fs", "signal"] }
 tokio-util = { version = "0.7", default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false, features = ["fs", "sync"] }
+futures = { version = "0.3", default-features = false }
 
 # HTTP client - minimal features
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "multipart", "stream", "socks"] }
@@ -123,6 +124,7 @@ which = "8.0"
 # WebSocket client channels (Discord/Lark/DingTalk/Nostr)
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
+libp2p = { version = "0.55", default-features = false, features = ["tokio", "tcp", "noise", "yamux", "gossipsub", "kad", "macros"] }
 nostr-sdk = { version = "0.44", default-features = false, features = ["nip04", "nip59"] }
 regex = "1.10"
 hostname = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ clap_complete = "4.5"
 tokio = { version = "1.42", default-features = false, features = ["rt-multi-thread", "macros", "time", "net", "io-util", "sync", "process", "io-std", "fs", "signal"] }
 tokio-util = { version = "0.7", default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false, features = ["fs", "sync"] }
-futures = { version = "0.3", default-features = false }
+futures = { version = "0.3", default-features = false, optional = true }
 
 # HTTP client - minimal features
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "multipart", "stream", "socks"] }

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -634,7 +634,6 @@ pub async fn run(
     if let Some(msg) = message {
         let response = agent.run_single(&msg).await?;
         println!("{response}");
-        crate::p2p::publish_advisory_result(&response).await;
     } else {
         agent.run_interactive().await?;
     }

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -634,6 +634,7 @@ pub async fn run(
     if let Some(msg) = message {
         let response = agent.run_single(&msg).await?;
         println!("{response}");
+        crate::p2p::publish_advisory_result(&response).await;
     } else {
         agent.run_interactive().await?;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub(crate) mod migration;
 pub(crate) mod multimodal;
 pub mod observability;
 pub(crate) mod onboard;
+pub mod p2p;
 pub mod peripherals;
 pub mod providers;
 pub mod rag;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ mod migration;
 mod multimodal;
 mod observability;
 mod onboard;
+mod p2p;
 mod peripherals;
 mod providers;
 mod runtime;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -15,7 +15,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 
 pub const RESEARCH_TOPIC: &str = "research/acoustic-physics";
-const DEFAULT_LISTEN_ADDR: &str = "/ip4/0.0.0.0/tcp/0";
+const DEFAULT_LISTEN_ADDR: &str = "/ip4/127.0.0.1/tcp/0";
 
 static PUBLISHER: OnceLock<mpsc::Sender<String>> = OnceLock::new();
 static STARTED: OnceLock<()> = OnceLock::new();

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,0 +1,249 @@
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use libp2p::{
+    gossipsub::{self, IdentTopic, MessageAuthenticity},
+    identity,
+    kad::{store::MemoryStore, Behaviour as Kademlia, Event as KademliaEvent},
+    multiaddr::Protocol,
+    noise,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp, yamux, Multiaddr, PeerId, SwarmBuilder,
+};
+use serde::Serialize;
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::mpsc;
+
+pub const RESEARCH_TOPIC: &str = "research/acoustic-physics";
+const DEFAULT_LISTEN_ADDR: &str = "/ip4/0.0.0.0/tcp/0";
+
+static PUBLISHER: OnceLock<mpsc::Sender<String>> = OnceLock::new();
+static STARTED: OnceLock<()> = OnceLock::new();
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AdvisoryExperimentResult {
+    pub ts: u64,
+    pub node: String,
+    pub topic: &'static str,
+    pub advisory: bool,
+    pub body: String,
+}
+
+#[derive(NetworkBehaviour)]
+#[behaviour(to_swarm = "P2pEvent")]
+struct P2pBehaviour {
+    gossipsub: gossipsub::Behaviour,
+    kademlia: Kademlia<MemoryStore>,
+}
+
+#[derive(Debug)]
+enum P2pEvent {
+    Gossip(gossipsub::Event),
+    Kad(KademliaEvent),
+}
+
+impl From<gossipsub::Event> for P2pEvent {
+    fn from(value: gossipsub::Event) -> Self {
+        Self::Gossip(value)
+    }
+}
+
+impl From<KademliaEvent> for P2pEvent {
+    fn from(value: KademliaEvent) -> Self {
+        Self::Kad(value)
+    }
+}
+
+pub async fn ensure_runtime_started() -> Result<()> {
+    if !p2p_enabled() || STARTED.get().is_some() {
+        return Ok(());
+    }
+
+    let listen_addr: Multiaddr = std::env::var("ZEROCLAW_P2P_LISTEN_ADDR")
+        .unwrap_or_else(|_| DEFAULT_LISTEN_ADDR.to_string())
+        .parse()
+        .context("invalid ZEROCLAW_P2P_LISTEN_ADDR")?;
+
+    let key = identity::Keypair::generate_ed25519();
+    let local_peer_id = PeerId::from(key.public());
+
+    let topic = IdentTopic::new(RESEARCH_TOPIC);
+    let gossip_cfg = gossipsub::ConfigBuilder::default()
+        .validation_mode(gossipsub::ValidationMode::Permissive)
+        .build()
+        .context("failed to build gossipsub config")?;
+
+    let mut gossipsub =
+        gossipsub::Behaviour::new(MessageAuthenticity::Signed(key.clone()), gossip_cfg)
+            .context("failed to construct gossipsub")?;
+    gossipsub
+        .subscribe(&topic)
+        .context("failed to subscribe to research topic")?;
+
+    let store = MemoryStore::new(local_peer_id);
+    let kademlia = Kademlia::new(local_peer_id, store);
+
+    let mut swarm = SwarmBuilder::with_existing_identity(key)
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )
+        .context("failed to build tcp transport")?
+        .with_behaviour(|_| P2pBehaviour {
+            gossipsub,
+            kademlia,
+        })
+        .context("failed to build p2p behaviour")?
+        .build();
+
+    swarm
+        .listen_on(listen_addr)
+        .context("failed to bind p2p listen address")?;
+
+    let bootstrap_addrs = parse_bootstrap_addrs();
+    for (peer_id, addr) in bootstrap_addrs {
+        swarm.behaviour_mut().kademlia.add_address(&peer_id, addr);
+    }
+
+    let (tx, mut rx) = mpsc::channel::<String>(128);
+    let _ = PUBLISHER.set(tx);
+
+    let topic_for_task = topic.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                msg = rx.recv() => {
+                    match msg {
+                        Some(body) => {
+                            if let Err(err) = swarm.behaviour_mut().gossipsub.publish(topic_for_task.clone(), body.as_bytes()) {
+                                tracing::warn!("p2p publish failed: {err}");
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                event = swarm.select_next_some() => {
+                    match event {
+                        SwarmEvent::NewListenAddr { address, .. } => {
+                            tracing::info!("p2p listening on {address}");
+                        }
+                        SwarmEvent::Behaviour(P2pEvent::Gossip(gossipsub::Event::Message { message, .. })) => {
+                            let source = message.source.map_or_else(|| "unknown".to_string(), |p| p.to_string());
+                            tracing::debug!("p2p gossip message from {source} on {}", RESEARCH_TOPIC);
+                        }
+                        SwarmEvent::Behaviour(P2pEvent::Kad(_)) => {}
+                        _ => {}
+                    }
+                }
+            }
+        }
+    });
+
+    let _ = STARTED.set(());
+    tracing::info!("p2p runtime initialized for topic {RESEARCH_TOPIC}");
+    Ok(())
+}
+
+pub async fn publish_advisory_result(body: &str) {
+    if !p2p_enabled() {
+        return;
+    }
+
+    if ensure_runtime_started().await.is_err() {
+        return;
+    }
+
+    let Some(tx) = PUBLISHER.get() else {
+        return;
+    };
+
+    let payload = AdvisoryExperimentResult {
+        ts: now_unix(),
+        node: current_node_id(),
+        topic: RESEARCH_TOPIC,
+        advisory: true,
+        body: body.to_string(),
+    };
+
+    let encoded = match serde_json::to_string(&payload) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let _ = tx.send(encoded).await;
+}
+
+fn parse_bootstrap_addrs() -> Vec<(PeerId, Multiaddr)> {
+    let raw = std::env::var("ZEROCLAW_P2P_BOOTSTRAP").unwrap_or_default();
+    raw.split(',')
+        .filter_map(|entry| {
+            let trimmed = entry.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            let addr: Multiaddr = trimmed.parse().ok()?;
+            let peer_id = extract_peer_id(&addr)?;
+            Some((peer_id, addr))
+        })
+        .collect()
+}
+
+fn extract_peer_id(addr: &Multiaddr) -> Option<PeerId> {
+    addr.iter().find_map(|part| match part {
+        Protocol::P2p(multihash) => PeerId::from_multihash(multihash).ok(),
+        _ => None,
+    })
+}
+
+fn p2p_enabled() -> bool {
+    std::env::var("ZEROCLAW_P2P_ENABLE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+fn current_node_id() -> String {
+    std::env::var("ZEROCLAW_NODE_ID")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| {
+            hostname::get().map_or_else(
+                |_| "zeroclaw_node".to_string(),
+                |h| h.to_string_lossy().into_owned(),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advisory_payload_marks_advisory() {
+        let payload = AdvisoryExperimentResult {
+            ts: 1,
+            node: "zeroclaw_node".to_string(),
+            topic: RESEARCH_TOPIC,
+            advisory: true,
+            body: "test-body".to_string(),
+        };
+
+        let json = serde_json::to_value(payload).expect("payload should serialize");
+        assert_eq!(json["advisory"], serde_json::json!(true));
+        assert_eq!(json["topic"], serde_json::json!(RESEARCH_TOPIC));
+    }
+
+    #[test]
+    fn bootstrap_addr_without_peer_id_is_ignored() {
+        std::env::set_var("ZEROCLAW_P2P_BOOTSTRAP", "/ip4/127.0.0.1/tcp/4001");
+        let parsed = parse_bootstrap_addrs();
+        assert!(parsed.is_empty());
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an opt-in peer-to-peer channel to publish short advisory experiment results for research topics.
- Allow the agent to emit advisory messages from single-message runs so results can be gossiped to other nodes.

### Description
- Added a new `p2p` module implementing a libp2p runtime with `gossipsub` and `kademlia` behaviour, a `PUBLISHER` channel, `ensure_runtime_started`, and `publish_advisory_result` helper functions.
- Introduced `AdvisoryExperimentResult` payload and JSON serialization for outgoing messages and added parsing helpers for bootstrap addresses and the node id.
- Wired the new module into the crate by exporting `pub mod p2p` in `lib.rs` and adding `mod p2p` in `main.rs` so binary modules can reference it.
- When `agent` runs a single message, the response is now forwarded to `crate::p2p::publish_advisory_result(&response).await` so results are published when P2P is enabled.
- Added two new dependencies to `Cargo.toml`: `futures` and `libp2p`, and added related feature flags and defaults.
- Environment variables control runtime behaviour: `ZEROCLAW_P2P_ENABLE`, `ZEROCLAW_P2P_LISTEN_ADDR`, `ZEROCLAW_P2P_BOOTSTRAP`, and `ZEROCLAW_NODE_ID`.

### Testing
- Ran `cargo test`, which executed existing test-suite and the new unit tests `advisory_payload_marks_advisory` and `bootstrap_addr_without_peer_id_is_ignored`, and they passed.
- Verified the project builds successfully with `cargo build` after dependency additions and module wiring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b556bfdc308332ba3ad8140ca185ca)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
