### PR TITLE
Add libp2p P2P module and publish agent advisory results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ which = "8.0"
 # WebSocket client channels (Discord/Lark/DingTalk/Nostr)
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
-libp2p = { version = "0.55", default-features = false, features = ["tokio", "tcp", "noise", "yamux", "gossipsub", "kad", "macros"] }
+libp2p = { version = "0.55", default-features = false, features = ["tokio", "tcp", "noise", "yamux", "gossipsub", "kad", "macros"], optional = true }
 nostr-sdk = { version = "0.44", default-features = false, features = ["nip04", "nip59"] }
 regex = "1.10"
 hostname = "0.4.2"
@@ -218,6 +218,8 @@ whatsapp-web = ["dep:wa-rs", "dep:wa-rs-core", "dep:wa-rs-binary", "dep:wa-rs-pr
 benchmarks = ["dep:criterion"]
 # Opt-in integration tests that require wiremock.
 test-wiremock = ["dep:wiremock"]
+# p2p = opt-in libp2p gossip + kademlia runtime
+p2p = ["dep:libp2p"]
 
 [profile.release]
 opt-level = "z"      # Optimize for size

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ clap_complete = "4.5"
 tokio = { version = "1.42", default-features = false, features = ["rt-multi-thread", "macros", "time", "net", "io-util", "sync", "process", "io-std", "fs", "signal"] }
 tokio-util = { version = "0.7", default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false, features = ["fs", "sync"] }
-futures = { version = "0.3", default-features = false }
 
 # HTTP client - minimal features
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "multipart", "stream", "socks"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ clap_complete = "4.5"
 tokio = { version = "1.42", default-features = false, features = ["rt-multi-thread", "macros", "time", "net", "io-util", "sync", "process", "io-std", "fs", "signal"] }
 tokio-util = { version = "0.7", default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false, features = ["fs", "sync"] }
+futures = { version = "0.3", default-features = false }
 
 # HTTP client - minimal features
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "multipart", "stream", "socks"] }
@@ -123,6 +124,7 @@ which = "8.0"
 # WebSocket client channels (Discord/Lark/DingTalk/Nostr)
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
+libp2p = { version = "0.55", default-features = false, features = ["tokio", "tcp", "noise", "yamux", "gossipsub", "kad", "macros"] }
 nostr-sdk = { version = "0.44", default-features = false, features = ["nip04", "nip59"] }
 regex = "1.10"
 hostname = "0.4.2"

--- a/src/agent/advisory.rs
+++ b/src/agent/advisory.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+
+pub trait AdvisoryPublisher: Send + Sync {
+    fn publish(&self, response: &str);
+}
+
+#[derive(Default)]
+pub struct NoopAdvisoryPublisher;
+
+impl AdvisoryPublisher for NoopAdvisoryPublisher {
+    fn publish(&self, _response: &str) {}
+}
+
+#[cfg(feature = "p2p")]
+pub struct P2pAdvisoryPublisher;
+
+#[cfg(feature = "p2p")]
+impl AdvisoryPublisher for P2pAdvisoryPublisher {
+    fn publish(&self, response: &str) {
+        let Some(sanitized) = sanitize_for_p2p(response) else {
+            return;
+        };
+        tokio::spawn(async move {
+            crate::p2p::publish_advisory_result(&sanitized).await;
+        });
+    }
+}
+
+pub fn build_publisher() -> Arc<dyn AdvisoryPublisher> {
+    #[cfg(feature = "p2p")]
+    {
+        if p2p_enabled() {
+            return Arc::new(P2pAdvisoryPublisher);
+        }
+    }
+
+    Arc::new(NoopAdvisoryPublisher)
+}
+
+#[cfg(feature = "p2p")]
+fn p2p_enabled() -> bool {
+    std::env::var("ZEROCLAW_P2P_ENABLE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+#[cfg(not(feature = "p2p"))]
+fn p2p_enabled() -> bool {
+    false
+}
+
+#[cfg(feature = "p2p")]
+fn sanitize_for_p2p(response: &str) -> Option<String> {
+    const MAX_LEN: usize = 512;
+    let lower = response.to_ascii_lowercase();
+    let blocked = [
+        "api_key",
+        "token",
+        "password",
+        "secret",
+        "bearer",
+        "credential",
+    ];
+    if blocked.iter().any(|k| lower.contains(k)) {
+        return None;
+    }
+
+    let trimmed = response.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut out = String::new();
+    for ch in trimmed.chars().take(MAX_LEN) {
+        out.push(ch);
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "p2p")]
+    #[test]
+    fn sanitize_blocks_sensitive_keywords() {
+        assert!(sanitize_for_p2p("token=abcd").is_none());
+    }
+
+    #[cfg(feature = "p2p")]
+    #[test]
+    fn sanitize_limits_output_size() {
+        let input = "x".repeat(600);
+        let output = sanitize_for_p2p(&input).expect("sanitized output expected");
+        assert_eq!(output.len(), 512);
+    }
+}

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -1,3 +1,4 @@
+use crate::agent::advisory::{self, AdvisoryPublisher};
 use crate::agent::dispatcher::{
     NativeToolDispatcher, ParsedToolCall, ToolDispatcher, ToolExecutionResult, XmlToolDispatcher,
 };
@@ -37,6 +38,7 @@ pub struct Agent {
     classification_config: crate::config::QueryClassificationConfig,
     available_hints: Vec<String>,
     route_model_by_hint: HashMap<String, String>,
+    advisory_publisher: Arc<dyn AdvisoryPublisher>,
 }
 
 pub struct AgentBuilder {
@@ -58,6 +60,7 @@ pub struct AgentBuilder {
     classification_config: Option<crate::config::QueryClassificationConfig>,
     available_hints: Option<Vec<String>>,
     route_model_by_hint: Option<HashMap<String, String>>,
+    advisory_publisher: Option<Arc<dyn AdvisoryPublisher>>,
 }
 
 impl AgentBuilder {
@@ -81,6 +84,7 @@ impl AgentBuilder {
             classification_config: None,
             available_hints: None,
             route_model_by_hint: None,
+            advisory_publisher: None,
         }
     }
 
@@ -180,6 +184,11 @@ impl AgentBuilder {
         self
     }
 
+    pub fn advisory_publisher(mut self, advisory_publisher: Arc<dyn AdvisoryPublisher>) -> Self {
+        self.advisory_publisher = Some(advisory_publisher);
+        self
+    }
+
     pub fn build(self) -> Result<Agent> {
         let tools = self
             .tools
@@ -223,6 +232,9 @@ impl AgentBuilder {
             classification_config: self.classification_config.unwrap_or_default(),
             available_hints: self.available_hints.unwrap_or_default(),
             route_model_by_hint: self.route_model_by_hint.unwrap_or_default(),
+            advisory_publisher: self
+                .advisory_publisher
+                .unwrap_or_else(advisory::build_publisher),
         })
     }
 }
@@ -588,7 +600,7 @@ impl Agent {
                 }
             };
             println!("\n{response}\n");
-            crate::p2p::publish_advisory_result(&response).await;
+            self.advisory_publisher.publish(&response);
         }
 
         listen_handle.abort();
@@ -635,7 +647,7 @@ pub async fn run(
     if let Some(msg) = message {
         let response = agent.run_single(&msg).await?;
         println!("{response}");
-        crate::p2p::publish_advisory_result(&response).await;
+        agent.advisory_publisher.publish(&response);
     } else {
         agent.run_interactive().await?;
     }

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -588,6 +588,7 @@ impl Agent {
                 }
             };
             println!("\n{response}\n");
+            crate::p2p::publish_advisory_result(&response).await;
         }
 
         listen_handle.abort();
@@ -634,6 +635,7 @@ pub async fn run(
     if let Some(msg) = message {
         let response = agent.run_single(&msg).await?;
         println!("{response}");
+        crate::p2p::publish_advisory_result(&response).await;
     } else {
         agent.run_interactive().await?;
     }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,4 +1,5 @@
 #[allow(clippy::module_inception)]
+pub mod advisory;
 pub mod agent;
 pub mod classifier;
 pub mod dispatcher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub(crate) mod migration;
 pub(crate) mod multimodal;
 pub mod observability;
 pub(crate) mod onboard;
+#[cfg(feature = "p2p")]
 pub mod p2p;
 pub mod peripherals;
 pub mod providers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub(crate) mod migration;
 pub(crate) mod multimodal;
 pub mod observability;
 pub(crate) mod onboard;
+pub mod p2p;
 pub mod peripherals;
 pub mod providers;
 pub mod rag;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ mod migration;
 mod multimodal;
 mod observability;
 mod onboard;
+#[cfg(feature = "p2p")]
 mod p2p;
 mod peripherals;
 mod providers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ mod migration;
 mod multimodal;
 mod observability;
 mod onboard;
+mod p2p;
 mod peripherals;
 mod providers;
 mod runtime;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -73,7 +73,7 @@ async fn init_runtime() -> Result<mpsc::Sender<String>> {
 
     let topic = IdentTopic::new(RESEARCH_TOPIC);
     let gossip_cfg = gossipsub::ConfigBuilder::default()
-        .validation_mode(gossipsub::ValidationMode::Permissive)
+        .validation_mode(gossipsub::ValidationMode::Strict)
         .build()
         .context("failed to build gossipsub config")?;
 

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use futures::StreamExt;
+use futures_util::StreamExt;
 use libp2p::{
     gossipsub::{self, IdentTopic, MessageAuthenticity},
     identity,

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -15,7 +15,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 
 pub const RESEARCH_TOPIC: &str = "research/acoustic-physics";
-const DEFAULT_LISTEN_ADDR: &str = "/ip4/0.0.0.0/tcp/0";
+const DEFAULT_LISTEN_ADDR: &str = "/ip4/127.0.0.1/tcp/0";
 
 static PUBLISHER: tokio::sync::OnceCell<mpsc::Sender<String>> = tokio::sync::OnceCell::const_new();
 
@@ -179,6 +179,10 @@ pub async fn publish_advisory_result(body: &str) {
 
 fn parse_bootstrap_addrs() -> Vec<(PeerId, Multiaddr)> {
     let raw = std::env::var("ZEROCLAW_P2P_BOOTSTRAP").unwrap_or_default();
+    parse_bootstrap_addrs_from(&raw)
+}
+
+fn parse_bootstrap_addrs_from(raw: &str) -> Vec<(PeerId, Multiaddr)> {
     raw.split(',')
         .filter_map(|entry| {
             let trimmed = entry.trim();
@@ -244,8 +248,7 @@ mod tests {
 
     #[test]
     fn bootstrap_addr_without_peer_id_is_ignored() {
-        std::env::set_var("ZEROCLAW_P2P_BOOTSTRAP", "/ip4/127.0.0.1/tcp/4001");
-        let parsed = parse_bootstrap_addrs();
+        let parsed = parse_bootstrap_addrs_from("/ip4/127.0.0.1/tcp/4001");
         assert!(parsed.is_empty());
     }
 }

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,0 +1,251 @@
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use libp2p::{
+    gossipsub::{self, IdentTopic, MessageAuthenticity},
+    identity,
+    kad::{store::MemoryStore, Behaviour as Kademlia, Event as KademliaEvent},
+    multiaddr::Protocol,
+    noise,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp, yamux, Multiaddr, PeerId, SwarmBuilder,
+};
+use serde::Serialize;
+
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::mpsc;
+
+pub const RESEARCH_TOPIC: &str = "research/acoustic-physics";
+const DEFAULT_LISTEN_ADDR: &str = "/ip4/0.0.0.0/tcp/0";
+
+static PUBLISHER: tokio::sync::OnceCell<mpsc::Sender<String>> = tokio::sync::OnceCell::const_new();
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AdvisoryExperimentResult {
+    pub ts: u64,
+    pub node: String,
+    pub topic: &'static str,
+    pub advisory: bool,
+    pub body: String,
+}
+
+#[derive(NetworkBehaviour)]
+#[behaviour(to_swarm = "P2pEvent")]
+struct P2pBehaviour {
+    gossipsub: gossipsub::Behaviour,
+    kademlia: Kademlia<MemoryStore>,
+}
+
+#[derive(Debug)]
+enum P2pEvent {
+    Gossip(gossipsub::Event),
+    Kad(KademliaEvent),
+}
+
+impl From<gossipsub::Event> for P2pEvent {
+    fn from(value: gossipsub::Event) -> Self {
+        Self::Gossip(value)
+    }
+}
+
+impl From<KademliaEvent> for P2pEvent {
+    fn from(value: KademliaEvent) -> Self {
+        Self::Kad(value)
+    }
+}
+
+pub async fn ensure_runtime_started() -> Result<()> {
+    if !p2p_enabled() {
+        return Ok(());
+    }
+
+    let _ = PUBLISHER.get_or_try_init(init_runtime).await?;
+    Ok(())
+}
+
+async fn init_runtime() -> Result<mpsc::Sender<String>> {
+    let listen_addr: Multiaddr = std::env::var("ZEROCLAW_P2P_LISTEN_ADDR")
+        .unwrap_or_else(|_| DEFAULT_LISTEN_ADDR.to_string())
+        .parse()
+        .context("invalid ZEROCLAW_P2P_LISTEN_ADDR")?;
+
+    let key = identity::Keypair::generate_ed25519();
+    let local_peer_id = PeerId::from(key.public());
+
+    let topic = IdentTopic::new(RESEARCH_TOPIC);
+    let gossip_cfg = gossipsub::ConfigBuilder::default()
+        .validation_mode(gossipsub::ValidationMode::Permissive)
+        .build()
+        .context("failed to build gossipsub config")?;
+
+    let mut gossipsub =
+        gossipsub::Behaviour::new(MessageAuthenticity::Signed(key.clone()), gossip_cfg)
+            .context("failed to construct gossipsub")?;
+    gossipsub
+        .subscribe(&topic)
+        .context("failed to subscribe to research topic")?;
+
+    let store = MemoryStore::new(local_peer_id);
+    let kademlia = Kademlia::new(local_peer_id, store);
+
+    let mut swarm = SwarmBuilder::with_existing_identity(key)
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )
+        .context("failed to build tcp transport")?
+        .with_behaviour(|_| P2pBehaviour {
+            gossipsub,
+            kademlia,
+        })
+        .context("failed to build p2p behaviour")?
+        .build();
+
+    swarm
+        .listen_on(listen_addr)
+        .context("failed to bind p2p listen address")?;
+
+    let bootstrap_addrs = parse_bootstrap_addrs();
+    for (peer_id, addr) in bootstrap_addrs {
+        swarm.behaviour_mut().kademlia.add_address(&peer_id, addr);
+    }
+
+    let (tx, mut rx) = mpsc::channel::<String>(128);
+    let topic_for_task = topic.clone();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                msg = rx.recv() => {
+                    match msg {
+                        Some(body) => {
+                            if let Err(err) = swarm.behaviour_mut().gossipsub.publish(topic_for_task.clone(), body.as_bytes()) {
+                                tracing::warn!("p2p publish failed: {err}");
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                event = swarm.select_next_some() => {
+                    match event {
+                        SwarmEvent::NewListenAddr { address, .. } => {
+                            tracing::info!("p2p listening on {address}");
+                        }
+                        SwarmEvent::Behaviour(P2pEvent::Gossip(gossipsub::Event::Message { message, .. })) => {
+                            let source = message.source.map_or_else(|| "unknown".to_string(), |p| p.to_string());
+                            tracing::debug!("p2p gossip message from {source} on {}", RESEARCH_TOPIC);
+                        }
+                        SwarmEvent::Behaviour(P2pEvent::Kad(_)) => {}
+                        _ => {}
+                    }
+                }
+            }
+        }
+    });
+
+    tracing::info!("p2p runtime initialized for topic {RESEARCH_TOPIC}");
+    Ok(tx)
+}
+
+pub async fn publish_advisory_result(body: &str) {
+    if !p2p_enabled() {
+        return;
+    }
+
+    if ensure_runtime_started().await.is_err() {
+        return;
+    }
+
+    let Some(tx) = PUBLISHER.get() else {
+        return;
+    };
+
+    let payload = AdvisoryExperimentResult {
+        ts: now_unix(),
+        node: current_node_id(),
+        topic: RESEARCH_TOPIC,
+        advisory: true,
+        body: body.to_string(),
+    };
+
+    let encoded = match serde_json::to_string(&payload) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let _ = tx.send(encoded).await;
+}
+
+fn parse_bootstrap_addrs() -> Vec<(PeerId, Multiaddr)> {
+    let raw = std::env::var("ZEROCLAW_P2P_BOOTSTRAP").unwrap_or_default();
+    raw.split(',')
+        .filter_map(|entry| {
+            let trimmed = entry.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            let addr: Multiaddr = trimmed.parse().ok()?;
+            let peer_id = extract_peer_id(&addr)?;
+            Some((peer_id, addr))
+        })
+        .collect()
+}
+
+fn extract_peer_id(addr: &Multiaddr) -> Option<PeerId> {
+    addr.iter().find_map(|part| match part {
+        Protocol::P2p(multihash) => PeerId::from_multihash(multihash).ok(),
+        _ => None,
+    })
+}
+
+fn p2p_enabled() -> bool {
+    std::env::var("ZEROCLAW_P2P_ENABLE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+fn current_node_id() -> String {
+    std::env::var("ZEROCLAW_NODE_ID")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| {
+            hostname::get().map_or_else(
+                |_| "zeroclaw_node".to_string(),
+                |h| h.to_string_lossy().into_owned(),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advisory_payload_marks_advisory() {
+        let payload = AdvisoryExperimentResult {
+            ts: 1,
+            node: "zeroclaw_node".to_string(),
+            topic: RESEARCH_TOPIC,
+            advisory: true,
+            body: "test-body".to_string(),
+        };
+
+        let json = serde_json::to_value(payload).expect("payload should serialize");
+        assert_eq!(json["advisory"], serde_json::json!(true));
+        assert_eq!(json["topic"], serde_json::json!(RESEARCH_TOPIC));
+    }
+
+    #[test]
+    fn bootstrap_addr_without_peer_id_is_ignored() {
+        std::env::set_var("ZEROCLAW_P2P_BOOTSTRAP", "/ip4/127.0.0.1/tcp/4001");
+        let parsed = parse_bootstrap_addrs();
+        assert!(parsed.is_empty());
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an opt-in P2P runtime for publishing agent advisory experiment results to a research topic and allow peers to subscribe to those messages. 
- Integrate lightweight gossip publishing into the interactive and single-run agent flows for telemetry/research sharing controlled by environment variables.

### Description
- Add a new `src/p2p/mod.rs` implementing a libp2p runtime with Gossipsub and Kademlia, functions `ensure_runtime_started`, `publish_advisory_result`, and helpers for bootstrap parsing and configuration via `ZEROCLAW_P2P_*` env vars. 
- Wire the new `p2p` module into the crate by exporting `pub mod p2p;` in `lib.rs` and importing `mod p2p;` in `main.rs`. 
- Call `crate::p2p::publish_advisory_result(&response).await` after producing agent responses in both `Agent::run_interactive` and the single-run branch of `run`. 
- Add dependencies to `Cargo.toml` (`futures` and `libp2p`) and include unit tests exercising payload serialization and bootstrap address parsing in the new module. 

### Testing
- Ran `cargo test`, and unit tests including the new `p2p` tests (`advisory_payload_marks_advisory` and `bootstrap_addr_without_peer_id_is_ignored`) completed successfully. 
- Built the project (`cargo build`) to ensure dependency addition and module integration compile cleanly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b556bfdc308332ba3ad8140ca185ca)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
