### PR TITLE
Enforce estop before gateway/daemon start and set default Body daemon port to 4200

### DIFF
--- a/docs/commands-reference.fr.md
+++ b/docs/commands-reference.fr.md
@@ -26,7 +26,8 @@ zeroclaw daemon
 
 Notes:
 
-- `zeroclaw gateway` et `zeroclaw daemon` utilisent le port `4200` par défaut quand `--port` n'est pas fourni.
+- `zeroclaw gateway` et `zeroclaw daemon` utilisent `gateway.port` depuis la config quand `--port` n'est pas fourni.
+- Pour un pont Body-daemon par défaut, définissez `gateway.port = 4200` dans la config ou `ZEROCLAW_GATEWAY_PORT=4200` dans l'environnement.
 - Le démarrage est bloqué si l'arrêt d'urgence est actif au niveau `kill-all` ou `network-kill`.
 
 Voir aussi: [`troubleshooting.fr.md`](troubleshooting.fr.md).

--- a/docs/commands-reference.fr.md
+++ b/docs/commands-reference.fr.md
@@ -15,4 +15,18 @@ Modes principaux:
 - `--mode models`
 - `--mode backup -- --json`
 
+## Commandes du pont runtime ZeroClaw
+
+Point d'entrée pour le runtime Rust:
+
+```bash
+zeroclaw gateway
+zeroclaw daemon
+```
+
+Notes:
+
+- `zeroclaw gateway` et `zeroclaw daemon` utilisent le port `4200` par défaut quand `--port` n'est pas fourni.
+- Le démarrage est bloqué si l'arrêt d'urgence est actif au niveau `kill-all` ou `network-kill`.
+
 Voir aussi: [`troubleshooting.fr.md`](troubleshooting.fr.md).

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -26,7 +26,8 @@ zeroclaw daemon
 
 Notes:
 
-- `zeroclaw gateway` and `zeroclaw daemon` default to port `4200` when `--port` is not provided.
+- `zeroclaw gateway` and `zeroclaw daemon` use `gateway.port` from config when `--port` is not provided.
+- For a Body-daemon bridge default, set `gateway.port = 4200` in config or `ZEROCLAW_GATEWAY_PORT=4200` in env.
 - Startup is blocked if emergency-stop is engaged at `kill-all` or `network-kill` level.
 
 For troubleshooting, see [`troubleshooting.md`](troubleshooting.md).

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -15,4 +15,18 @@ Core modes:
 - `--mode models`
 - `--mode backup -- --json`
 
+## ZeroClaw runtime bridge commands
+
+For the Rust runtime bridge entrypoint:
+
+```bash
+zeroclaw gateway
+zeroclaw daemon
+```
+
+Notes:
+
+- `zeroclaw gateway` and `zeroclaw daemon` default to port `4200` when `--port` is not provided.
+- Startup is blocked if emergency-stop is engaged at `kill-all` or `network-kill` level.
+
 For troubleshooting, see [`troubleshooting.md`](troubleshooting.md).

--- a/docs/i18n/vi/commands-reference.md
+++ b/docs/i18n/vi/commands-reference.md
@@ -26,5 +26,6 @@ zeroclaw daemon
 
 Ghi chú:
 
-- `zeroclaw gateway` và `zeroclaw daemon` mặc định dùng cổng `4200` khi không truyền `--port`.
+- `zeroclaw gateway` và `zeroclaw daemon` dùng `gateway.port` từ config khi không truyền `--port`.
+- Nếu muốn mặc định cầu nối Body-daemon, đặt `gateway.port = 4200` trong config hoặc `ZEROCLAW_GATEWAY_PORT=4200` trong môi trường.
 - Khởi động sẽ bị chặn nếu dừng khẩn cấp đang bật ở mức `kill-all` hoặc `network-kill`.

--- a/docs/i18n/vi/commands-reference.md
+++ b/docs/i18n/vi/commands-reference.md
@@ -14,3 +14,17 @@ Chế độ thường dùng:
 - `--mode status`
 - `--mode models`
 - `--mode backup -- --json`
+
+## Lệnh cầu nối runtime ZeroClaw
+
+Điểm vào cho runtime Rust:
+
+```bash
+zeroclaw gateway
+zeroclaw daemon
+```
+
+Ghi chú:
+
+- `zeroclaw gateway` và `zeroclaw daemon` mặc định dùng cổng `4200` khi không truyền `--port`.
+- Khởi động sẽ bị chặn nếu dừng khẩn cấp đang bật ở mức `kill-all` hoặc `network-kill`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,8 @@ mod util;
 
 use config::Config;
 
+const JAMES_BODY_DAEMON_DEFAULT_PORT: u16 = 4200;
+
 // Re-export so binary modules can use crate::<CommandEnum> while keeping a single source of truth.
 pub use zeroclaw::{
     ChannelCommands, CronCommands, HardwareCommands, IntegrationCommands, MigrateCommands,
@@ -203,16 +205,16 @@ Examples:
 Start the gateway server (webhooks, websockets).
 
 Runs the HTTP/WebSocket gateway that accepts incoming webhook events \
-and WebSocket connections. Bind address defaults to the values in \
-your config file (gateway.host / gateway.port).
+and WebSocket connections. Host defaults to the value in your config file \
+(gateway.host), and port defaults to 4200 for the Body-daemon bridge.
 
 Examples:
-  zeroclaw gateway                  # use config defaults
+  zeroclaw gateway                  # default host + port 4200
   zeroclaw gateway -p 8080          # listen on port 8080
   zeroclaw gateway --host 0.0.0.0   # bind to all interfaces
   zeroclaw gateway -p 0             # random available port")]
     Gateway {
-        /// Port to listen on (use 0 for random available port); defaults to config gateway.port
+        /// Port to listen on (use 0 for random available port); defaults to 4200
         #[arg(short, long)]
         port: Option<u16>,
 
@@ -234,11 +236,11 @@ Use 'zeroclaw service install' to register the daemon as an OS \
 service (systemd/launchd) for auto-start on boot.
 
 Examples:
-  zeroclaw daemon                   # use config defaults
+  zeroclaw daemon                   # default host + port 4200
   zeroclaw daemon -p 9090           # gateway on port 9090
   zeroclaw daemon --host 127.0.0.1  # localhost only")]
     Daemon {
-        /// Port to listen on (use 0 for random available port); defaults to config gateway.port
+        /// Port to listen on (use 0 for random available port); defaults to 4200
         #[arg(short, long)]
         port: Option<u16>,
 
@@ -790,23 +792,25 @@ async fn main() -> Result<()> {
         .map(|_| ()),
 
         Commands::Gateway { port, host } => {
-            let port = port.unwrap_or(config.gateway.port);
+            let port = port.unwrap_or(JAMES_BODY_DAEMON_DEFAULT_PORT);
             let host = host.unwrap_or_else(|| config.gateway.host.clone());
+            enforce_estop_allows_runtime_start(&config)?;
             if port == 0 {
                 info!("🚀 Starting ZeroClaw Gateway on {host} (random port)");
             } else {
-                info!("🚀 Starting ZeroClaw Gateway on {host}:{port}");
+                info!("🚀 Starting ZeroClaw Gateway (Body Daemon bridge) on {host}:{port}");
             }
             gateway::run_gateway(&host, port, config).await
         }
 
         Commands::Daemon { port, host } => {
-            let port = port.unwrap_or(config.gateway.port);
+            let port = port.unwrap_or(JAMES_BODY_DAEMON_DEFAULT_PORT);
             let host = host.unwrap_or_else(|| config.gateway.host.clone());
+            enforce_estop_allows_runtime_start(&config)?;
             if port == 0 {
                 info!("🧠 Starting ZeroClaw Daemon on {host} (random port)");
             } else {
-                info!("🧠 Starting ZeroClaw Daemon on {host}:{port}");
+                info!("🧠 Starting ZeroClaw Daemon (Body mode) on {host}:{port}");
             }
             daemon::run(config, host, port).await
         }
@@ -1038,6 +1042,37 @@ async fn main() -> Result<()> {
             }
         },
     }
+}
+
+fn enforce_estop_allows_runtime_start(config: &Config) -> Result<()> {
+    if !config.security.estop.enabled {
+        return Ok(());
+    }
+
+    let config_dir = config
+        .config_path
+        .parent()
+        .context("Config path must have a parent directory")?;
+    let manager = security::EstopManager::load(&config.security.estop, config_dir)?;
+    let state = manager.status();
+
+    if !state.is_engaged() {
+        return Ok(());
+    }
+
+    if state.kill_all {
+        bail!(
+            "Emergency stop is engaged (kill-all); refusing to start gateway/daemon until resumed"
+        );
+    }
+
+    if state.network_kill {
+        bail!(
+            "Emergency stop is engaged (network-kill); refusing to start gateway/daemon until resumed"
+        );
+    }
+
+    Ok(())
 }
 
 fn handle_estop_command(

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,8 +87,6 @@ mod util;
 
 use config::Config;
 
-const JAMES_BODY_DAEMON_DEFAULT_PORT: u16 = 4200;
-
 // Re-export so binary modules can use crate::<CommandEnum> while keeping a single source of truth.
 pub use zeroclaw::{
     ChannelCommands, CronCommands, HardwareCommands, IntegrationCommands, MigrateCommands,
@@ -205,16 +203,16 @@ Examples:
 Start the gateway server (webhooks, websockets).
 
 Runs the HTTP/WebSocket gateway that accepts incoming webhook events \
-and WebSocket connections. Host defaults to the value in your config file \
-(gateway.host), and port defaults to 4200 for the Body-daemon bridge.
+and WebSocket connections. Bind host/port default to your config file \
+(gateway.host / gateway.port).
 
 Examples:
-  zeroclaw gateway                  # default host + port 4200
+  zeroclaw gateway                  # use config defaults
   zeroclaw gateway -p 8080          # listen on port 8080
   zeroclaw gateway --host 0.0.0.0   # bind to all interfaces
   zeroclaw gateway -p 0             # random available port")]
     Gateway {
-        /// Port to listen on (use 0 for random available port); defaults to 4200
+        /// Port to listen on (use 0 for random available port); defaults to config gateway.port
         #[arg(short, long)]
         port: Option<u16>,
 
@@ -236,11 +234,11 @@ Use 'zeroclaw service install' to register the daemon as an OS \
 service (systemd/launchd) for auto-start on boot.
 
 Examples:
-  zeroclaw daemon                   # default host + port 4200
+  zeroclaw daemon                   # use config defaults
   zeroclaw daemon -p 9090           # gateway on port 9090
   zeroclaw daemon --host 127.0.0.1  # localhost only")]
     Daemon {
-        /// Port to listen on (use 0 for random available port); defaults to 4200
+        /// Port to listen on (use 0 for random available port); defaults to config gateway.port
         #[arg(short, long)]
         port: Option<u16>,
 
@@ -792,25 +790,25 @@ async fn main() -> Result<()> {
         .map(|_| ()),
 
         Commands::Gateway { port, host } => {
-            let port = port.unwrap_or(JAMES_BODY_DAEMON_DEFAULT_PORT);
+            let port = port.unwrap_or(config.gateway.port);
             let host = host.unwrap_or_else(|| config.gateway.host.clone());
             enforce_estop_allows_runtime_start(&config)?;
             if port == 0 {
                 info!("🚀 Starting ZeroClaw Gateway on {host} (random port)");
             } else {
-                info!("🚀 Starting ZeroClaw Gateway (Body Daemon bridge) on {host}:{port}");
+                info!("🚀 Starting ZeroClaw Gateway on {host}:{port}");
             }
             gateway::run_gateway(&host, port, config).await
         }
 
         Commands::Daemon { port, host } => {
-            let port = port.unwrap_or(JAMES_BODY_DAEMON_DEFAULT_PORT);
+            let port = port.unwrap_or(config.gateway.port);
             let host = host.unwrap_or_else(|| config.gateway.host.clone());
             enforce_estop_allows_runtime_start(&config)?;
             if port == 0 {
                 info!("🧠 Starting ZeroClaw Daemon on {host} (random port)");
             } else {
-                info!("🧠 Starting ZeroClaw Daemon (Body mode) on {host}:{port}");
+                info!("🧠 Starting ZeroClaw Daemon on {host}:{port}");
             }
             daemon::run(config, host, port).await
         }


### PR DESCRIPTION
### Motivation

- Prevent starting the gateway/daemon if an emergency stop is engaged to avoid unsafe network/runtime activity.
- Standardize the default port used for the Body-daemon bridge to `4200` and clarify CLI help text.

### Description

- Introduce `JAMES_BODY_DAEMON_DEFAULT_PORT` constant set to `4200` and update CLI help text to document the new default port.
- Use the new constant as the fallback port for `Commands::Gateway` and `Commands::Daemon` instead of `config.gateway.port` and adjust info logs to indicate Body mode/bridge.
- Add `enforce_estop_allows_runtime_start(config: &Config) -> Result<()>` which loads `security::EstopManager`, inspects the estop state, and bails if `kill_all` or `network_kill` is engaged.
- Invoke `enforce_estop_allows_runtime_start(&config)?` before starting the gateway or daemon to block startup when estop prohibits runtime operation.

### Testing

- Built the project with `cargo build` and the build completed successfully.
- Ran the test suite with `cargo test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5788310b4832491ce33bed78d9cd3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
