### PR TITLE
Add Rust daemon bridge and agent registry support; enforce estop before starting runtime

### DIFF
--- a/bootstrap_local.py
+++ b/bootstrap_local.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+from agents import PEER_REVIEW_PROTOCOL, STAGE_PROTOCOL
 
 
 def _venv_python(venv_dir: Path) -> Path:
@@ -65,7 +68,106 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Delete and recreate virtual environment if it already exists.",
     )
+    parser.add_argument(
+        "--register-rust-agents",
+        action="store_true",
+        help="Register James/Jasmine/Luca/Elena with local Rust daemon registry.",
+    )
+    parser.add_argument(
+        "--rust-api-url",
+        default=os.environ.get("RAIN_RUST_DAEMON_API_URL", "http://127.0.0.1:4200"),
+        help="Rust daemon API base URL used for agent registration.",
+    )
+    parser.add_argument(
+        "--registry-output",
+        default="meeting_archives/rust_agent_registry.json",
+        help="Where to write the generated Rust-agent registry JSON snapshot.",
+    )
     return parser.parse_args(argv)
+
+
+def _build_rust_agent_registry() -> dict:
+    stage_prompt = STAGE_PROTOCOL.strip()
+    peer_review_prompt = PEER_REVIEW_PROTOCOL.strip()
+
+    base_prompt = (
+        f"{stage_prompt}\n\n"
+        f"{peer_review_prompt}\n\n"
+        "You must preserve epistemic hygiene, avoid unsupported claims, "
+        "and clearly mark speculation when evidence is incomplete."
+    )
+
+    agents = [
+        {
+            "id": "james",
+            "name": "James",
+            "role": "Lead Scientist/Technician",
+            "system_prompt": (
+                f"{base_prompt}\n\n"
+                "Primary objective: coordinate hypotheses, simulation framing, and synthesis quality."
+            ),
+            "skills": ["web-search"],
+        },
+        {
+            "id": "jasmine",
+            "name": "Jasmine",
+            "role": "Hardware Architect",
+            "system_prompt": (
+                f"{base_prompt}\n\n"
+                "Primary objective: enforce hardware feasibility and realistic implementation constraints."
+            ),
+            "skills": ["web-search"],
+        },
+        {
+            "id": "luca",
+            "name": "Luca",
+            "role": "Field Tomographer / Theorist",
+            "system_prompt": (
+                f"{base_prompt}\n\n"
+                "Primary objective: challenge topology/field assumptions and maintain rigorous math checks."
+            ),
+            "skills": ["web-search", "docker"],
+        },
+        {
+            "id": "elena",
+            "name": "Elena",
+            "role": "Quantum Information Theorist",
+            "system_prompt": (
+                f"{base_prompt}\n\n"
+                "Primary objective: audit computational bounds, coherence limits, and information-theoretic validity."
+            ),
+            "skills": ["web-search", "docker"],
+        },
+    ]
+
+    return {
+        "registry_version": "v1",
+        "agents": agents,
+    }
+
+
+def _register_rust_agents(repo_root: Path, rust_api_url: str, output_path: Path) -> None:
+    payload = _build_rust_agent_registry()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"[bootstrap] wrote registry snapshot: {output_path}")
+
+    try:
+        import httpx
+
+        with httpx.Client(timeout=httpx.Timeout(20.0, connect=5.0)) as client:
+            response = client.post(
+                f"{rust_api_url.rstrip('/')}/v1/registry/agents/bulk",
+                json=payload,
+            )
+            response.raise_for_status()
+            print("[bootstrap] rust agent registration: success")
+    except Exception as exc:
+        print(f"[bootstrap] rust agent registration skipped/failed: {exc}")
+        print(
+            "[bootstrap] You can import the generated snapshot manually into the Rust daemon registry."
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -96,6 +198,13 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args.skip_preflight:
         _run([str(venv_python), "rain_lab.py", "--mode", "preflight"], cwd=repo_root)
+
+    if args.register_rust_agents:
+        _register_rust_agents(
+            repo_root=repo_root,
+            rust_api_url=args.rust_api_url,
+            output_path=(repo_root / args.registry_output).resolve(),
+        )
 
     print("\n[bootstrap] done")
     print(f"[bootstrap] activate env: {venv_dir}")

--- a/docs/commands-reference.fr.md
+++ b/docs/commands-reference.fr.md
@@ -15,4 +15,19 @@ Modes principaux:
 - `--mode models`
 - `--mode backup -- --json`
 
+## Commandes du pont runtime ZeroClaw
+
+Point d'entrée pour le runtime Rust:
+
+```bash
+zeroclaw gateway
+zeroclaw daemon
+```
+
+Notes:
+
+- `zeroclaw gateway` et `zeroclaw daemon` utilisent `gateway.port` depuis la config quand `--port` n'est pas fourni.
+- Pour un pont Body-daemon par défaut, définissez `gateway.port = 4200` dans la config ou `ZEROCLAW_GATEWAY_PORT=4200` dans l'environnement.
+- Le démarrage est bloqué si l'arrêt d'urgence est actif au niveau `kill-all` ou `network-kill`.
+
 Voir aussi: [`troubleshooting.fr.md`](troubleshooting.fr.md).

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -15,4 +15,19 @@ Core modes:
 - `--mode models`
 - `--mode backup -- --json`
 
+## ZeroClaw runtime bridge commands
+
+For the Rust runtime bridge entrypoint:
+
+```bash
+zeroclaw gateway
+zeroclaw daemon
+```
+
+Notes:
+
+- `zeroclaw gateway` and `zeroclaw daemon` use `gateway.port` from config when `--port` is not provided.
+- For a Body-daemon bridge default, set `gateway.port = 4200` in config or `ZEROCLAW_GATEWAY_PORT=4200` in env.
+- Startup is blocked if emergency-stop is engaged at `kill-all` or `network-kill` level.
+
 For troubleshooting, see [`troubleshooting.md`](troubleshooting.md).

--- a/docs/i18n/vi/commands-reference.md
+++ b/docs/i18n/vi/commands-reference.md
@@ -14,3 +14,18 @@ Chế độ thường dùng:
 - `--mode status`
 - `--mode models`
 - `--mode backup -- --json`
+
+## Lệnh cầu nối runtime ZeroClaw
+
+Điểm vào cho runtime Rust:
+
+```bash
+zeroclaw gateway
+zeroclaw daemon
+```
+
+Ghi chú:
+
+- `zeroclaw gateway` và `zeroclaw daemon` dùng `gateway.port` từ config khi không truyền `--port`.
+- Nếu muốn mặc định cầu nối Body-daemon, đặt `gateway.port = 4200` trong config hoặc `ZEROCLAW_GATEWAY_PORT=4200` trong môi trường.
+- Khởi động sẽ bị chặn nếu dừng khẩn cấp đang bật ở mức `kill-all` hoặc `network-kill`.

--- a/rain_lab_meeting_chat_version.py
+++ b/rain_lab_meeting_chat_version.py
@@ -165,7 +165,7 @@ DEFAULT_LIBRARY_EXCLUDE_DIRS = _parse_env_csv(
 
 )
 
-from typing import List, Dict, Optional, Tuple
+from typing import List, Dict, Optional, Tuple, Any
 
 from dataclasses import dataclass, field
 
@@ -559,6 +559,11 @@ class Config:
     export_tts_audio: bool = os.environ.get("RAIN_EXPORT_TTS_AUDIO", "1") != "0"
 
     tts_audio_dir: str = os.environ.get("RAIN_TTS_AUDIO_DIR", "meeting_archives/tts_audio")
+
+    # Rust daemon bridge settings (PR B)
+    use_rust_daemon: bool = os.environ.get("RAIN_USE_RUST_DAEMON", "0") == "1"
+    rust_daemon_api_url: str = os.environ.get("RAIN_RUST_DAEMON_API_URL", "http://127.0.0.1:4200")
+    rust_daemon_timeout: float = float(os.environ.get("RAIN_RUST_DAEMON_TIMEOUT", "120"))
 
 
 
@@ -2038,6 +2043,58 @@ class Diplomat:
 
 
 
+
+class RustDaemonClient:
+    """HTTP bridge client for local Rust daemon orchestration."""
+
+    def __init__(self, base_url: str, timeout_s: float):
+        import httpx
+
+        self.base_url = base_url.rstrip("/")
+        self.client = httpx.Client(timeout=httpx.Timeout(timeout_s, connect=min(10.0, timeout_s)))
+
+    def request_agent_response(
+        self,
+        *,
+        agent_name: str,
+        topic: str,
+        context_block: str,
+        recent_chat: str,
+        mission: str,
+        max_tokens: int,
+        temperature: float,
+    ) -> str:
+        payload = {
+            "agent": agent_name,
+            "topic": topic,
+            "context": context_block,
+            "recent_chat": recent_chat,
+            "mission": mission,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+        response = self.client.post(f"{self.base_url}/v1/agents/respond", json=payload)
+        response.raise_for_status()
+        data = response.json()
+        content = (data.get("content") or "").strip()
+        if not content:
+            raise RuntimeError("Rust daemon returned empty content")
+        return content
+
+    def poll_events(self) -> List[Dict[str, Any]]:
+        try:
+            response = self.client.get(f"{self.base_url}/v1/events/poll")
+            if response.status_code >= 400:
+                return []
+            data = response.json()
+            events = data.get("events", [])
+            if isinstance(events, list):
+                return [event for event in events if isinstance(event, dict)]
+            return []
+        except Exception:
+            return []
+
+
 # --- MAIN ORCHESTRATOR ---
 
 class RainLabOrchestrator:
@@ -2083,45 +2140,57 @@ class RainLabOrchestrator:
 
         
 
+        self.rust_daemon_client: Optional[RustDaemonClient] = None
+
         # LLM client with extended timeout for large context processing
 
-        try:
+        if self.config.use_rust_daemon:
+            try:
+                self.rust_daemon_client = RustDaemonClient(
+                    base_url=self.config.rust_daemon_api_url,
+                    timeout_s=self.config.rust_daemon_timeout,
+                )
+                self.client = None
+                print(f"🦀 Rust daemon mode enabled: {self.config.rust_daemon_api_url}")
+            except Exception as e:
+                print(f"❌ Failed to initialize Rust daemon client: {e}")
+                sys.exit(1)
+        else:
+            try:
 
-            import httpx
+                import httpx
 
-            # Allow configurable read timeout for slower local models / larger contexts
+                # Allow configurable read timeout for slower local models / larger contexts
 
-            connect_timeout = min(15.0, self.config.timeout)
+                connect_timeout = min(15.0, self.config.timeout)
 
-            custom_timeout = httpx.Timeout(
+                custom_timeout = httpx.Timeout(
 
-                connect_timeout,
+                    connect_timeout,
 
-                read=self.config.timeout,
+                    read=self.config.timeout,
 
-                write=connect_timeout,
+                    write=connect_timeout,
 
-                connect=connect_timeout,
+                    connect=connect_timeout,
 
-            )
+                )
 
-            self.client = openai.OpenAI(
+                self.client = openai.OpenAI(
 
-                base_url=config.base_url, 
+                    base_url=config.base_url, 
 
-                api_key=config.api_key,
+                    api_key=config.api_key,
 
-                timeout=custom_timeout
+                    timeout=custom_timeout
 
-            )
+                )
 
-        except Exception as e:
+            except Exception as e:
 
-            print(f"❌ Failed to initialize OpenAI client: {e}")
+                print(f"❌ Failed to initialize OpenAI client: {e}")
 
-            sys.exit(1)
-
-
+                sys.exit(1)
 
     def _emit_visual_event(self, payload: Dict):
 
@@ -2855,6 +2924,54 @@ class RainLabOrchestrator:
 
 
 
+    def _poll_daemon_events(self):
+        if not self.rust_daemon_client:
+            return
+
+        for event in self.rust_daemon_client.poll_events():
+            self._emit_visual_event(event)
+            if str(event.get("type", "")) == "agent_utterance":
+                text = sanitize_text(str(event.get("content", "")))
+                agent_name = str(event.get("agent_name", "")) or None
+                if text:
+                    self.voice_engine.speak(text, agent_name=agent_name)
+
+    def _create_response_content(
+        self,
+        *,
+        agent: Agent,
+        topic: str,
+        context_block: str,
+        recent_chat: str,
+        mission: str,
+        user_msg: str,
+    ) -> Tuple[str, Optional[str]]:
+        if self.rust_daemon_client is not None:
+            self._poll_daemon_events()
+            content = self.rust_daemon_client.request_agent_response(
+                agent_name=agent.name,
+                topic=topic,
+                context_block=context_block,
+                recent_chat=recent_chat,
+                mission=mission,
+                max_tokens=self.config.max_tokens,
+                temperature=self.config.temperature,
+            )
+            return content, None
+
+        response = self.client.chat.completions.create(
+            model=self.config.model_name,
+            messages=[
+                {"role": "system", "content": f"{agent.soul}\n\n### RESEARCH DATABASE\n{context_block}"},
+                {"role": "user", "content": user_msg}
+            ],
+            temperature=self.config.temperature,
+            max_tokens=self.config.max_tokens
+        )
+        content = response.choices[0].message.content.strip()
+        finish_reason = response.choices[0].finish_reason if hasattr(response.choices[0], "finish_reason") else None
+        return content, finish_reason
+
     def _generate_agent_response(
 
         self, 
@@ -3108,32 +3225,15 @@ HIDDEN CONNECTIONS (KNOWLEDGE HYPERGRAPH):
 Use these links to propose creative cross-paper insights if relevant.
 
 """
-
-                
-
-                # Use system message for static context (better caching)
-
-                response = self.client.chat.completions.create(
-
-                    model=self.config.model_name,
-
-                    messages=[
-
-                        {"role": "system", "content": f"{agent.soul}\n\n### RESEARCH DATABASE\n{context_block}"},
-
-                        {"role": "user", "content": user_msg}
-
-                    ],
-
-                    temperature=self.config.temperature,
-
-                    max_tokens=self.config.max_tokens
-
+                # Use daemon bridge or direct provider call for primary generation
+                content, finish_reason = self._create_response_content(
+                    agent=agent,
+                    topic=topic,
+                    context_block=context_block,
+                    recent_chat=recent_chat,
+                    mission=mission,
+                    user_msg=user_msg,
                 )
-
-                
-
-                content = response.choices[0].message.content.strip()
 
 
 
@@ -3321,7 +3421,6 @@ Use these links to propose creative cross-paper insights if relevant.
 
                 # Check if response was truncated (doesn't end with sentence-ending punctuation)
 
-                finish_reason = response.choices[0].finish_reason if hasattr(response.choices[0], 'finish_reason') else None
 
                 is_truncated = finish_reason == "length" or (
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,8 +203,8 @@ Examples:
 Start the gateway server (webhooks, websockets).
 
 Runs the HTTP/WebSocket gateway that accepts incoming webhook events \
-and WebSocket connections. Bind address defaults to the values in \
-your config file (gateway.host / gateway.port).
+and WebSocket connections. Bind host/port default to your config file \
+(gateway.host / gateway.port).
 
 Examples:
   zeroclaw gateway                  # use config defaults
@@ -792,6 +792,7 @@ async fn main() -> Result<()> {
         Commands::Gateway { port, host } => {
             let port = port.unwrap_or(config.gateway.port);
             let host = host.unwrap_or_else(|| config.gateway.host.clone());
+            enforce_estop_allows_runtime_start(&config)?;
             if port == 0 {
                 info!("🚀 Starting ZeroClaw Gateway on {host} (random port)");
             } else {
@@ -803,6 +804,7 @@ async fn main() -> Result<()> {
         Commands::Daemon { port, host } => {
             let port = port.unwrap_or(config.gateway.port);
             let host = host.unwrap_or_else(|| config.gateway.host.clone());
+            enforce_estop_allows_runtime_start(&config)?;
             if port == 0 {
                 info!("🧠 Starting ZeroClaw Daemon on {host} (random port)");
             } else {
@@ -1038,6 +1040,37 @@ async fn main() -> Result<()> {
             }
         },
     }
+}
+
+fn enforce_estop_allows_runtime_start(config: &Config) -> Result<()> {
+    if !config.security.estop.enabled {
+        return Ok(());
+    }
+
+    let config_dir = config
+        .config_path
+        .parent()
+        .context("Config path must have a parent directory")?;
+    let manager = security::EstopManager::load(&config.security.estop, config_dir)?;
+    let state = manager.status();
+
+    if !state.is_engaged() {
+        return Ok(());
+    }
+
+    if state.kill_all {
+        bail!(
+            "Emergency stop is engaged (kill-all); refusing to start gateway/daemon until resumed"
+        );
+    }
+
+    if state.network_kill {
+        bail!(
+            "Emergency stop is engaged (network-kill); refusing to start gateway/daemon until resumed"
+        );
+    }
+
+    Ok(())
 }
 
 fn handle_estop_command(


### PR DESCRIPTION
### Motivation

- Integrate a local Rust runtime/daemon (ZeroClaw) as an alternate LLM/agent backend and provide tooling to register/export agent definitions for that runtime.
- Provide a reproducible way to generate and snapshot a Rust-agent registry and to POST it to a running Rust daemon from the Python bootstrap flow.
- Prevent accidental runtime startup while emergency-stop is engaged by enforcing estop state checks before starting gateway/daemon.

### Description

- Add CLI flags to `bootstrap_local.py` (`--register-rust-agents`, `--rust-api-url`, `--registry-output`) and implement `_build_rust_agent_registry` and `_register_rust_agents` to generate a JSON registry snapshot and optionally POST it to the Rust daemon using `httpx`; also import `json` and `PEER_REVIEW_PROTOCOL`/`STAGE_PROTOCOL` from `agents` to seed system prompts.
- Update docs (`docs/commands-reference.*` and translations) to document the `zeroclaw gateway` / `zeroclaw daemon` runtime bridge commands and notes about default ports and emergency-stop behavior.
- In `rain_lab_meeting_chat_version.py` add config flags (`use_rust_daemon`, `rust_daemon_api_url`, `rust_daemon_timeout`), a `RustDaemonClient` HTTP bridge class, and orchestrator changes to initialize and use the Rust daemon client when enabled, including polling events (`_poll_daemon_events`) and routing agent response generation through the daemon via `_create_response_content` while preserving the original provider path.
- Minor typing/import adjustments in `rain_lab_meeting_chat_version.py` and cleanup of LLM client initialization when `use_rust_daemon` is enabled.
- In `src/main.rs` update help text and add `enforce_estop_allows_runtime_start` which loads `EstopManager` and refuses to start `Gateway`/`Daemon` when `kill_all` or `network_kill` are engaged, and call this check before starting gateway/daemon.

### Testing

- Built the Rust workspace with `cargo build` to validate compilation and the new `enforce_estop_allows_runtime_start` integration; build succeeded.
- Ran Python CLI smoke tests including `python bootstrap_local.py --help` and `python rain_lab_meeting_chat_version.py --help` to validate new flags and imports; help/smoke checks succeeded.
- Ran repository unit/linters (Python `pytest`/`flake8` and Rust `cargo test` where applicable) as part of CI smoke validation; automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5788310b4832491ce33bed78d9cd3)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
