### PR TITLE
feat(providers): add 17 providers + critical bug fixes from upstream

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -120,6 +120,9 @@ const MEMORY_CONTEXT_ENTRY_MAX_CHARS: usize = 800;
 const MEMORY_CONTEXT_MAX_CHARS: usize = 4_000;
 const CHANNEL_HISTORY_COMPACT_KEEP_MESSAGES: usize = 12;
 const CHANNEL_HISTORY_COMPACT_CONTENT_CHARS: usize = 600;
+/// Proactive context budget (~100k tokens) to prevent context-window-exceeded
+/// errors on long-running channel sessions.
+const PROACTIVE_CONTEXT_BUDGET_CHARS: usize = 400_000;
 /// Guardrail for hook-modified outbound channel content.
 const CHANNEL_HOOK_MAX_OUTBOUND_CHARS: usize = 20_000;
 
@@ -475,6 +478,31 @@ fn normalize_cached_channel_turns(turns: Vec<ChatMessage>) -> Vec<ChatMessage> {
     }
 
     normalized
+}
+
+/// Drop oldest turns (preserving the most recent) until total character count
+/// fits within [`PROACTIVE_CONTEXT_BUDGET_CHARS`]. Prevents context-window-exceeded
+/// errors on long-running channel sessions.
+fn proactive_trim_turns(turns: &mut Vec<ChatMessage>) {
+    let total: usize = turns.iter().map(|t| t.content.len()).sum();
+    if total <= PROACTIVE_CONTEXT_BUDGET_CHARS || turns.len() <= 1 {
+        return;
+    }
+    let mut current = total;
+    let mut drop_count = 0;
+    // Always preserve the last turn (most recent user message).
+    while current > PROACTIVE_CONTEXT_BUDGET_CHARS && drop_count < turns.len() - 1 {
+        current -= turns[drop_count].content.len();
+        drop_count += 1;
+    }
+    if drop_count > 0 {
+        tracing::info!(
+            dropped = drop_count,
+            remaining = turns.len() - drop_count,
+            "proactive context trim: dropped oldest turns to fit budget"
+        );
+        turns.drain(..drop_count);
+    }
 }
 
 fn supports_runtime_model_switch(channel_name: &str) -> bool {
@@ -1626,6 +1654,9 @@ async fn process_channel_message(
             }
         }
     }
+
+    // Proactively trim oldest turns to prevent context-window-exceeded errors.
+    proactive_trim_turns(&mut prior_turns);
 
     let system_prompt =
         build_channel_system_prompt(ctx.system_prompt.as_str(), &msg.channel, &msg.reply_target);

--- a/src/channels/nextcloud_talk.rs
+++ b/src/channels/nextcloud_talk.rs
@@ -70,7 +70,9 @@ impl NextcloudTalkChannel {
         let mut messages = Vec::new();
 
         if let Some(event_type) = payload.get("type").and_then(|v| v.as_str()) {
-            if !event_type.eq_ignore_ascii_case("message") {
+            let is_message_event = event_type.eq_ignore_ascii_case("message")
+                || event_type.eq_ignore_ascii_case("Create");
+            if !is_message_event {
                 tracing::debug!("Nextcloud Talk: skipping non-message event: {event_type}");
                 return messages;
             }

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -177,7 +177,9 @@ fn format_attachment_content(
     local_path: &Path,
 ) -> String {
     match kind {
-        IncomingAttachmentKind::Photo if is_image_extension(local_path) => {
+        IncomingAttachmentKind::Photo | IncomingAttachmentKind::Document
+            if is_image_extension(local_path) =>
+        {
             format!("[IMAGE:{}]", local_path.display())
         }
         _ => {
@@ -244,6 +246,25 @@ fn strip_tool_call_tags(message: &str) -> String {
     super::strip_tool_call_tags(message)
 }
 
+/// Find the position of the matching `]` for a substring starting just after
+/// `[`, handling nested brackets (e.g. filenames like `Video [G4PvTrTp7Tc].mp4`).
+fn find_matching_close(s: &str) -> Option<usize> {
+    let mut depth = 1usize;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 fn parse_attachment_markers(message: &str) -> (String, Vec<TelegramAttachment>) {
     let mut cleaned = String::with_capacity(message.len());
     let mut attachments = Vec::new();
@@ -258,12 +279,12 @@ fn parse_attachment_markers(message: &str) -> (String, Vec<TelegramAttachment>) 
         let open = cursor + open_rel;
         cleaned.push_str(&message[cursor..open]);
 
-        let Some(close_rel) = message[open..].find(']') else {
+        let Some(close_rel) = find_matching_close(&message[open + 1..]) else {
             cleaned.push_str(&message[open..]);
             break;
         };
 
-        let close = open + close_rel;
+        let close = open + 1 + close_rel;
         let marker = &message[open + 1..close];
 
         let parsed = marker.split_once(':').and_then(|(kind, target)| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::assigning_clones,

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -308,7 +308,7 @@ impl AnthropicProvider {
                             role: "assistant".to_string(),
                             content: blocks,
                         });
-                    } else {
+                    } else if !msg.content.trim().is_empty() {
                         native_messages.push(NativeMessage {
                             role: "assistant".to_string(),
                             content: vec![NativeContentOut::Text {
@@ -319,26 +319,55 @@ impl AnthropicProvider {
                     }
                 }
                 "tool" => {
-                    if let Some(tool_result) = Self::parse_tool_result_message(&msg.content) {
-                        native_messages.push(tool_result);
+                    let tool_msg = if let Some(tr) = Self::parse_tool_result_message(&msg.content) {
+                        tr
+                    } else if msg.content.trim().is_empty() {
+                        continue;
                     } else {
-                        native_messages.push(NativeMessage {
+                        NativeMessage {
                             role: "user".to_string(),
                             content: vec![NativeContentOut::Text {
                                 text: msg.content.clone(),
                                 cache_control: None,
                             }],
-                        });
+                        }
+                    };
+                    // Tool results map to role "user"; merge consecutive ones
+                    // into a single message so Anthropic doesn't reject the
+                    // request for having adjacent same-role messages.
+                    if native_messages
+                        .last()
+                        .is_some_and(|m| m.role == tool_msg.role)
+                    {
+                        native_messages
+                            .last_mut()
+                            .unwrap()
+                            .content
+                            .extend(tool_msg.content);
+                    } else {
+                        native_messages.push(tool_msg);
                     }
                 }
                 _ => {
-                    native_messages.push(NativeMessage {
-                        role: "user".to_string(),
-                        content: vec![NativeContentOut::Text {
-                            text: msg.content.clone(),
-                            cache_control: None,
-                        }],
-                    });
+                    let content_blocks = vec![NativeContentOut::Text {
+                        text: msg.content.clone(),
+                        cache_control: None,
+                    }];
+                    // Merge into previous user message if present (e.g.
+                    // when a user message immediately follows tool results
+                    // which are also role "user" in Anthropic's format).
+                    if native_messages.last().is_some_and(|m| m.role == "user") {
+                        native_messages
+                            .last_mut()
+                            .unwrap()
+                            .content
+                            .extend(content_blocks);
+                    } else {
+                        native_messages.push(NativeMessage {
+                            role: "user".to_string(),
+                            content: content_blocks,
+                        });
+                    }
                 }
             }
         }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1208,6 +1208,69 @@ fn create_provider_with_url_and_options(
             key,
         ))),
 
+        // ── Fast inference providers ──────────────────────────
+        "cerebras" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Cerebras", "https://api.cerebras.ai/v1", key, AuthStyle::Bearer,
+        ))),
+        "sambanova" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "SambaNova", "https://api.sambanova.ai/v1", key, AuthStyle::Bearer,
+        ))),
+        "hyperbolic" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Hyperbolic", "https://api.hyperbolic.xyz/v1", key, AuthStyle::Bearer,
+        ))),
+
+        // ── Model hosting providers ─────────────────────────
+        "deepinfra" | "deep-infra" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "DeepInfra", "https://api.deepinfra.com/v1/openai", key, AuthStyle::Bearer,
+        ))),
+        "huggingface" | "hf" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Hugging Face", "https://api-inference.huggingface.co/v1", key, AuthStyle::Bearer,
+        ))),
+        "ai21" | "ai21-labs" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "AI21 Labs", "https://api.ai21.com/studio/v1", key, AuthStyle::Bearer,
+        ))),
+        "reka" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Reka", "https://api.reka.ai/v1", key, AuthStyle::Bearer,
+        ))),
+        "baseten" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Baseten", "https://bridge.baseten.co/v1", key, AuthStyle::Bearer,
+        ))),
+        "nscale" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Nscale", "https://inference.nscale.com/v1", key, AuthStyle::Bearer,
+        ))),
+        "anyscale" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Anyscale", "https://api.endpoints.anyscale.com/v1", key, AuthStyle::Bearer,
+        ))),
+        "nebius" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Nebius", "https://api.studio.nebius.ai/v1", key, AuthStyle::Bearer,
+        ))),
+        "friendli" | "friendliai" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "FriendliAI", "https://inference.friendli.ai/v1", key, AuthStyle::Bearer,
+        ))),
+        "lepton" | "lepton-ai" => {
+            let base_url = api_url
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or("https://llama3-1-405b.lepton.run/api/v1");
+            Ok(Box::new(OpenAiCompatibleProvider::new(
+                "Lepton AI", base_url, key, AuthStyle::Bearer,
+            )))
+        }
+
+        // ── Chinese AI providers ────────────────────────────
+        "stepfun" | "step" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "StepFun", "https://api.stepfun.com/v1", key, AuthStyle::Bearer,
+        ))),
+        "baichuan" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Baichuan", "https://api.baichuan-ai.com/v1", key, AuthStyle::Bearer,
+        ))),
+        "yi" | "01ai" | "lingyiwanwu" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Yi (01.AI)", "https://api.lingyiwanwu.com/v1", key, AuthStyle::Bearer,
+        ))),
+        "hunyuan" | "tencent" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Tencent Hunyuan", "https://api.hunyuan.cloud.tencent.com/v1", key, AuthStyle::Bearer,
+        ))),
+
         // ── Bring Your Own Provider (custom URL) ───────────
         // Format: "custom:https://your-api.com" or "custom:http://localhost:1234"
         name if name.starts_with("custom:") => {
@@ -1703,6 +1766,124 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             name: "ovhcloud",
             display_name: "OVHcloud AI Endpoints",
             aliases: &["ovh"],
+            local: false,
+        },
+        // ── Fast inference ──
+        ProviderInfo {
+            name: "cerebras",
+            display_name: "Cerebras",
+            aliases: &[],
+            local: false,
+        },
+        ProviderInfo {
+            name: "sambanova",
+            display_name: "SambaNova",
+            aliases: &[],
+            local: false,
+        },
+        ProviderInfo {
+            name: "hyperbolic",
+            display_name: "Hyperbolic",
+            aliases: &[],
+            local: false,
+        },
+        // ── Model hosting ──
+        ProviderInfo {
+            name: "deepinfra",
+            display_name: "DeepInfra",
+            aliases: &["deep-infra"],
+            local: false,
+        },
+        ProviderInfo {
+            name: "huggingface",
+            display_name: "Hugging Face",
+            aliases: &["hf"],
+            local: false,
+        },
+        ProviderInfo {
+            name: "ai21",
+            display_name: "AI21 Labs",
+            aliases: &["ai21-labs"],
+            local: false,
+        },
+        ProviderInfo {
+            name: "reka",
+            display_name: "Reka",
+            aliases: &[],
+            local: false,
+        },
+        ProviderInfo {
+            name: "baseten",
+            display_name: "Baseten",
+            aliases: &[],
+            local: false,
+        },
+        ProviderInfo {
+            name: "nscale",
+            display_name: "Nscale",
+            aliases: &[],
+            local: false,
+        },
+        ProviderInfo {
+            name: "anyscale",
+            display_name: "Anyscale",
+            aliases: &[],
+            local: false,
+        },
+        ProviderInfo {
+            name: "nebius",
+            display_name: "Nebius",
+            aliases: &[],
+            local: false,
+        },
+        ProviderInfo {
+            name: "friendli",
+            display_name: "FriendliAI",
+            aliases: &["friendliai"],
+            local: false,
+        },
+        ProviderInfo {
+            name: "lepton",
+            display_name: "Lepton AI",
+            aliases: &["lepton-ai"],
+            local: false,
+        },
+        // ── Chinese AI ──
+        ProviderInfo {
+            name: "stepfun",
+            display_name: "StepFun",
+            aliases: &["step"],
+            local: false,
+        },
+        ProviderInfo {
+            name: "baichuan",
+            display_name: "Baichuan",
+            aliases: &[],
+            local: false,
+        },
+        ProviderInfo {
+            name: "yi",
+            display_name: "Yi (01.AI)",
+            aliases: &["01ai", "lingyiwanwu"],
+            local: false,
+        },
+        ProviderInfo {
+            name: "hunyuan",
+            display_name: "Tencent Hunyuan",
+            aliases: &["tencent"],
+            local: false,
+        },
+        // ── Missing entries ──
+        ProviderInfo {
+            name: "telnyx",
+            display_name: "Telnyx",
+            aliases: &[],
+            local: false,
+        },
+        ProviderInfo {
+            name: "azure_openai",
+            display_name: "Azure OpenAI",
+            aliases: &[],
             local: false,
         },
     ]


### PR DESCRIPTION
Cherry-pick key improvements from zeroclaw-labs/zeroclaw (v0.2.0–v0.3.1) without merging the full upstream history.

Bug fixes:
- Anthropic: merge consecutive same-role messages to prevent 500 errors
- Anthropic: skip empty text content blocks in API requests
- Channels: proactive context trimming (400k char budget) prevents context-window-exceeded errors on long sessions
- Telegram: route Document attachments with image extensions through vision pipeline
- Telegram: depth-tracking bracket matching for filenames like Video [id].mp4
- Nextcloud Talk: accept "Create" event type alongside "message"
- Matrix: increase recursion_limit to 256 for matrix-sdk 0.16

New providers (17):
- Fast inference: Cerebras, SambaNova, Hyperbolic
- Model hosting: DeepInfra, Hugging Face, AI21 Labs, Reka, Baseten, Nscale, Anyscale, Nebius, FriendliAI, Lepton AI
- Chinese AI: StepFun, Baichuan, Yi (01.AI), Tencent Hunyuan
- Added missing list_providers entries for Telnyx and Azure OpenAI

https://claude.ai/code/session_01ExN5dawtDdsrHTDSS19ZQe

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion):
- Problem:
- Why it matters:
- What changed:
- What did **not** change (scope boundary):

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`):
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Mitigation:

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
