### PR TITLE
Remove Azure OpenAI provider and fix shell test flags

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1880,12 +1880,6 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             aliases: &[],
             local: false,
         },
-        ProviderInfo {
-            name: "azure_openai",
-            display_name: "Azure OpenAI",
-            aliases: &[],
-            local: false,
-        },
     ]
 }
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1085,7 +1085,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn run_capture_reads_stdout() {
-        let out = run_capture(Command::new("sh").args(["-lc", "echo hello"]))
+        let out = run_capture(Command::new("sh").args(["-c", "echo hello"]))
             .expect("stdout capture should succeed");
         assert_eq!(out.trim(), "hello");
     }
@@ -1093,7 +1093,7 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn run_capture_falls_back_to_stderr() {
-        let out = run_capture(Command::new("sh").args(["-lc", "echo warn 1>&2"]))
+        let out = run_capture(Command::new("sh").args(["-c", "echo warn 1>&2"]))
             .expect("stderr capture should succeed");
         assert_eq!(out.trim(), "warn");
     }


### PR DESCRIPTION
## Summary

- Base branch target: `dev`
- Problem: Azure OpenAI provider entry is listed but not implemented; shell test commands use incorrect login shell flag
- Why it matters: Removes dead code from provider list; fixes test reliability by using correct shell invocation
- What changed: Removed `azure_openai` from provider list; changed `-lc` to `-c` in two shell command tests
- What did **not** change: No changes to actual provider implementations or core service logic

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `provider,tests`
- Module labels: `provider: azure_openai`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: None

## Change Metadata

- Change type: `chore`
- Primary scope: `provider`

## Linked Issue

- Closes: (none specified)
- Related: (none specified)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided: Existing unit tests in `src/service/mod.rs` (`run_capture_reads_stdout`, `run_capture_falls_back_to_stderr`) now use correct shell flags and will pass
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: N/A

## Compatibility / Migration

- Backward compatible? `Yes` (removal of non-functional provider entry)
- Config/env changes? `No`
- Migration needed? `No`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Shell test flags corrected from `-lc` (login shell) to `-c` (non-login shell) for non-interactive test execution
- Edge cases checked: N/A
- What was not verified: N/A

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Provider listing, shell command execution tests
- Potential unintended effects: None
- Guardrails/monitoring for early detection: Existing unit tests validate behavior

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-hash>`
- Feature flags or config toggles (if any): None
- Observable failure symptoms: Tests would fail if shell flags were incorrect

## Risks and Mitigations

- Risk: Removing provider entry may affect code that references `azure_openai` by name
  - Mitigation: Provider list is internal; no external API dependency on this entry

https://claude.ai/code/session_01AhYbS1LfGLz7R4n4t3a7pJ
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
