### PR TITLE
Add resonance/cymatic visualization for frequency discussions

### DIFF
--- a/godot_client/contracts/NEUTRAL_EVENT_CONTRACT.md
+++ b/godot_client/contracts/NEUTRAL_EVENT_CONTRACT.md
@@ -14,6 +14,7 @@ The Godot client maps these events to theme-specific visuals/audio.
 - `agent_utterance_chunk`
 - `agent_emote`
 - `theme_changed`
+- `resonance_state`
 
 ## Example Payloads
 
@@ -68,6 +69,28 @@ The Godot client maps these events to theme-specific visuals/audio.
 {
   "type": "theme_changed",
   "theme_id": "lab"
+}
+```
+
+### `resonance_state`
+
+Emitted when agents discuss specific frequencies, acoustic physics, or reach
+consensus on resonance parameters.  The Godot client uses these values to drive
+a shader-based cymatic/Chladni-plate visualisation overlay.
+
+| Field                 | Type  | Range       | Description                                                                 |
+|-----------------------|-------|-------------|-----------------------------------------------------------------------------|
+| `target_frequency`    | float | > 0         | Dominant frequency (Hz) under discussion. Controls nodal pattern complexity. |
+| `amplitude`           | float | 0.0 – 1.0  | Signal strength / visual intensity of the pattern.                          |
+| `consensus_stability` | float | 0.0 – 1.0  | How settled the group is on the value. 1.0 = perfectly symmetric pattern; 0.0 = jittery/chaotic. |
+
+```json
+{
+  "type": "resonance_state",
+  "conversation_id": "c_42",
+  "target_frequency": 432.0,
+  "amplitude": 0.75,
+  "consensus_stability": 0.6
 }
 ```
 

--- a/godot_client/data/demo_events.json
+++ b/godot_client/data/demo_events.json
@@ -49,12 +49,22 @@
         "type": "agent_utterance",
         "turn_id": "t_003",
         "agent_id": "elena",
-        "text": "Same conversation, different environment. Background, UI skin, ambience, and sprite palettes all changed.",
-        "tone": "neutral",
+        "text": "Let me propose a resonance experiment. We should examine standing wave formation at 432 Hz on a Chladni plate with fine sand medium.",
+        "tone": "focused",
         "audio": {
           "mode": "synthetic",
-          "duration_ms": 3800
+          "duration_ms": 4200
         }
+      }
+    },
+    {
+      "delay_s": 0.3,
+      "event": {
+        "type": "resonance_state",
+        "conversation_id": "demo_001",
+        "target_frequency": 432.0,
+        "amplitude": 0.55,
+        "consensus_stability": 0.3
       }
     },
     {
@@ -63,12 +73,70 @@
         "type": "agent_utterance",
         "turn_id": "t_004",
         "agent_id": "luca",
-        "text": "During each utterance, the active speaker animates while everyone else stays visible in the same scene.",
+        "text": "Agreed on 432 Hz. The nodal patterns at that frequency should produce a characteristic four-fold symmetric cymatic figure. The amplitude needs to be high enough to overcome damping.",
         "tone": "excited",
         "audio": {
           "mode": "synthetic",
-          "duration_ms": 3600
+          "duration_ms": 4600
         }
+      }
+    },
+    {
+      "delay_s": 0.3,
+      "event": {
+        "type": "resonance_state",
+        "conversation_id": "demo_001",
+        "target_frequency": 432.0,
+        "amplitude": 0.75,
+        "consensus_stability": 0.7
+      }
+    },
+    {
+      "delay_s": 0.8,
+      "event": {
+        "type": "agent_utterance",
+        "turn_id": "t_005",
+        "agent_id": "james",
+        "text": "Beautiful. Both of you converge on 432 Hz with high confidence. The eigenfrequency alignment is clear and the simulation confirms stable nodal lines.",
+        "tone": "excited",
+        "audio": {
+          "mode": "synthetic",
+          "duration_ms": 4000
+        }
+      }
+    },
+    {
+      "delay_s": 0.3,
+      "event": {
+        "type": "resonance_state",
+        "conversation_id": "demo_001",
+        "target_frequency": 432.0,
+        "amplitude": 0.9,
+        "consensus_stability": 0.95
+      }
+    },
+    {
+      "delay_s": 0.6,
+      "event": {
+        "type": "agent_utterance",
+        "turn_id": "t_006",
+        "agent_id": "jasmine",
+        "text": "What if we shift to 528 Hz? The harmonic relationship between 432 and 528 might reveal interesting interference at the vibration boundary.",
+        "tone": "curious",
+        "audio": {
+          "mode": "synthetic",
+          "duration_ms": 4400
+        }
+      }
+    },
+    {
+      "delay_s": 0.3,
+      "event": {
+        "type": "resonance_state",
+        "conversation_id": "demo_001",
+        "target_frequency": 528.0,
+        "amplitude": 0.65,
+        "consensus_stability": 0.35
       }
     },
     {

--- a/godot_client/scripts/background_painter.gd
+++ b/godot_client/scripts/background_painter.gd
@@ -2,19 +2,33 @@ extends Node2D
 class_name BackgroundPainter
 
 const GRADIENT_SHADER_PATH := "res://shaders/background_gradient.gdshader"
+const CYMATICS_SHADER_PATH := "res://shaders/cymatics_overlay.gdshader"
 
 var _theme_id: String = "flower_field"
 var _background_cfg: Dictionary = {}
 var _seed: int = 1
 var _gradient_rect: ColorRect
+var _cymatics_rect: ColorRect
+
+# Resonance state — smoothly interpolated toward targets.
+var _res_freq_target: float = 0.0
+var _res_freq_current: float = 0.0
+var _res_amp_target: float = 0.0
+var _res_amp_current: float = 0.0
+var _res_stab_target: float = 0.5
+var _res_stab_current: float = 0.5
+var _res_time: float = 0.0
+const _RES_LERP_SPEED: float = 3.0
 
 
 func _ready() -> void:
 	_ensure_gradient_layer()
+	_ensure_cymatics_layer()
 	var viewport := get_viewport()
 	if viewport != null:
 		viewport.size_changed.connect(_on_viewport_size_changed)
 	_sync_gradient_rect()
+	_sync_cymatics_rect()
 	_apply_gradient_to_shader()
 
 
@@ -23,11 +37,35 @@ func apply_theme(theme_id: String, background_cfg: Dictionary) -> void:
 	_background_cfg = background_cfg.duplicate(true)
 	_seed = abs(hash(theme_id)) + 17
 	_apply_gradient_to_shader()
+
+	# Apply optional per-theme cymatics line colour.
+	var cymatics_hex := str(background_cfg.get("cymatics_line_color", ""))
+	if cymatics_hex != "" and _cymatics_rect != null:
+		var mat: Variant = _cymatics_rect.material
+		if mat is ShaderMaterial:
+			(mat as ShaderMaterial).set_shader_parameter("line_color", Color(cymatics_hex))
+
 	queue_redraw()
+
+
+func apply_resonance(freq: float, amp: float, stability: float) -> void:
+	_res_freq_target = freq
+	_res_amp_target = clampf(amp, 0.0, 1.0)
+	_res_stab_target = clampf(stability, 0.0, 1.0)
+
+
+func _process(delta: float) -> void:
+	# Smoothly interpolate resonance uniforms toward targets.
+	_res_freq_current = lerpf(_res_freq_current, _res_freq_target, minf(1.0, delta * _RES_LERP_SPEED))
+	_res_amp_current = lerpf(_res_amp_current, _res_amp_target, minf(1.0, delta * _RES_LERP_SPEED))
+	_res_stab_current = lerpf(_res_stab_current, _res_stab_target, minf(1.0, delta * _RES_LERP_SPEED))
+	_res_time += delta
+	_apply_cymatics_uniforms()
 
 
 func _on_viewport_size_changed() -> void:
 	_sync_gradient_rect()
+	_sync_cymatics_rect()
 	queue_redraw()
 
 
@@ -41,6 +79,43 @@ func _draw() -> void:
 		_draw_lab(size, horizon_y)
 	else:
 		_draw_flower_field(size, horizon_y)
+
+
+func _ensure_cymatics_layer() -> void:
+	if _cymatics_rect != null:
+		return
+	_cymatics_rect = ColorRect.new()
+	_cymatics_rect.name = "CymaticsRect"
+	_cymatics_rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_cymatics_rect.z_index = -99  # Just above gradient, below everything else.
+	add_child(_cymatics_rect)
+
+	var shader := load(CYMATICS_SHADER_PATH)
+	if shader is Shader:
+		var material := ShaderMaterial.new()
+		material.shader = shader
+		_cymatics_rect.material = material
+
+
+func _sync_cymatics_rect() -> void:
+	if _cymatics_rect == null:
+		return
+	var rect := get_viewport_rect()
+	_cymatics_rect.position = rect.position
+	_cymatics_rect.size = rect.size
+
+
+func _apply_cymatics_uniforms() -> void:
+	if _cymatics_rect == null:
+		return
+	var mat: Variant = _cymatics_rect.material
+	if not (mat is ShaderMaterial):
+		return
+	var shader_mat := mat as ShaderMaterial
+	shader_mat.set_shader_parameter("target_frequency", _res_freq_current)
+	shader_mat.set_shader_parameter("amplitude", _res_amp_current)
+	shader_mat.set_shader_parameter("consensus_stability", _res_stab_current)
+	shader_mat.set_shader_parameter("time_s", _res_time)
 
 
 func _ensure_gradient_layer() -> void:

--- a/godot_client/scripts/background_painter.gd
+++ b/godot_client/scripts/background_painter.gd
@@ -43,7 +43,7 @@ func apply_theme(theme_id: String, background_cfg: Dictionary) -> void:
 	if cymatics_hex != "" and _cymatics_rect != null:
 		var mat: Variant = _cymatics_rect.material
 		if mat is ShaderMaterial:
-			(mat as ShaderMaterial).set_shader_parameter("line_color", Color(cymatics_hex))
+			(mat as ShaderMaterial).set_shader_parameter("line_color", _color_from(cymatics_hex, "#66d9ff"))
 
 	queue_redraw()
 

--- a/godot_client/scripts/scene_orchestrator.gd
+++ b/godot_client/scripts/scene_orchestrator.gd
@@ -84,6 +84,8 @@ func _on_event_received(event_payload: Dictionary) -> void:
 			_handle_agent_chunk(event_payload)
 		"theme_changed":
 			_handle_theme_changed(event_payload)
+		"resonance_state":
+			_handle_resonance_state(event_payload)
 		"conversation_ended":
 			_handle_conversation_ended()
 		"conversation_reset":
@@ -135,6 +137,13 @@ func _handle_theme_changed(event_payload: Dictionary) -> void:
 	var requested_theme := str(event_payload.get("theme_id", "")).strip_edges()
 	if requested_theme != "":
 		_theme_manager.apply_theme(requested_theme)
+
+
+func _handle_resonance_state(event_payload: Dictionary) -> void:
+	var freq := float(event_payload.get("target_frequency", 0.0))
+	var amp := clampf(float(event_payload.get("amplitude", 0.0)), 0.0, 1.0)
+	var stability := clampf(float(event_payload.get("consensus_stability", 0.0)), 0.0, 1.0)
+	_background_layer.apply_resonance(freq, amp, stability)
 
 
 func _handle_conversation_ended() -> void:

--- a/godot_client/scripts/scene_orchestrator.gd
+++ b/godot_client/scripts/scene_orchestrator.gd
@@ -149,12 +149,14 @@ func _handle_resonance_state(event_payload: Dictionary) -> void:
 func _handle_conversation_ended() -> void:
 	_audio_sync.stop_current_utterance(true)
 	_set_active_speaker("")
+	_background_layer.apply_resonance(0.0, 0.0, 0.5)
 	_dialogue_ui.show_status("Conversation ended.")
 
 
 func _handle_conversation_reset() -> void:
 	_audio_sync.stop_current_utterance(true)
 	_spawn_participants([])
+	_background_layer.apply_resonance(0.0, 0.0, 0.5)
 	_dialogue_ui.show_status("Replay reset.")
 
 

--- a/godot_client/shaders/cymatics_overlay.gdshader
+++ b/godot_client/shaders/cymatics_overlay.gdshader
@@ -1,0 +1,82 @@
+shader_type canvas_item;
+
+// Resonance event data (set from GDScript).
+uniform float target_frequency : hint_range(20.0, 2000.0) = 0.0;
+uniform float amplitude : hint_range(0.0, 1.0) = 0.0;
+uniform float consensus_stability : hint_range(0.0, 1.0) = 0.5;
+
+// Internal animation clock (seconds, advanced from GDScript).
+uniform float time_s : hint_range(0.0, 100000.0) = 0.0;
+
+// Tint colour for the nodal lines.
+uniform vec4 line_color : source_color = vec4(0.4, 0.85, 1.0, 1.0);
+
+// --- Chladni plate equation ---
+// Classic rectangular Chladni pattern:  f(x,y) = cos(n*pi*x) * cos(m*pi*y) - cos(m*pi*x) * cos(n*pi*y)
+// We derive (n, m) from target_frequency so higher frequencies yield denser
+// nodal grids, and we blend two mode-pairs for visual richness.
+
+float chladni(vec2 uv, float n, float m) {
+	float a = cos(n * 3.14159 * uv.x) * cos(m * 3.14159 * uv.y);
+	float b = cos(m * 3.14159 * uv.x) * cos(n * 3.14159 * uv.y);
+	return a - b;
+}
+
+void fragment() {
+	// When amplitude is zero the overlay is fully transparent — no work needed.
+	if (amplitude < 0.001) {
+		COLOR = vec4(0.0);
+		return;
+	}
+
+	// Map frequency to mode indices (n, m).  Low frequencies → simple patterns,
+	// high frequencies → intricate grids.
+	float freq_norm = clamp((target_frequency - 20.0) / 1980.0, 0.0, 1.0);
+	float base_n = mix(1.0, 6.0, freq_norm);
+	float base_m = mix(2.0, 9.0, freq_norm);
+
+	// Jitter: low consensus_stability adds time-varying wobble to mode indices.
+	float jitter = (1.0 - consensus_stability) * 0.6;
+	float wobble = sin(time_s * 3.7) * jitter;
+	float wobble2 = cos(time_s * 2.3) * jitter;
+
+	float n1 = base_n + wobble;
+	float m1 = base_m + wobble2;
+	float n2 = base_n * 0.7 + wobble2 * 0.5;
+	float m2 = base_m * 1.3 - wobble * 0.5;
+
+	// Centre UVs around origin and scale to [-1, 1].
+	vec2 uv = UV * 2.0 - 1.0;
+
+	// Optional slow rotation when stability is low.
+	float angle = time_s * 0.15 * (1.0 - consensus_stability);
+	float ca = cos(angle);
+	float sa = sin(angle);
+	uv = vec2(uv.x * ca - uv.y * sa, uv.x * sa + uv.y * ca);
+
+	// Evaluate two Chladni modes and blend.
+	float c1 = chladni(uv, n1, m1);
+	float c2 = chladni(uv, n2, m2);
+	float pattern = mix(c1, c2, 0.35 + 0.15 * sin(time_s * 0.5));
+
+	// Nodal lines are where pattern ≈ 0.  Use smoothstep for soft edges.
+	float line_width = mix(0.18, 0.08, consensus_stability);
+	float nodal = 1.0 - smoothstep(0.0, line_width, abs(pattern));
+
+	// Ripple ring emanating from centre (frequency-scaled).
+	float dist = length(uv);
+	float ring = sin(dist * base_n * 4.0 - time_s * 2.5) * 0.5 + 0.5;
+	ring = smoothstep(0.42, 0.48, ring);
+
+	// Composite: nodal lines + subtle ripple ring.
+	float composite = max(nodal, ring * 0.35);
+
+	// Final alpha driven by amplitude.
+	float alpha = composite * amplitude * 0.55;
+
+	// Slight brightness pulse keyed to stability.
+	float pulse = 1.0 + 0.12 * sin(time_s * 1.8) * (1.0 - consensus_stability);
+	vec3 col = line_color.rgb * pulse;
+
+	COLOR = vec4(col, alpha);
+}

--- a/rain_lab_meeting_chat_version.py
+++ b/rain_lab_meeting_chat_version.py
@@ -64,6 +64,85 @@ RE_CORRUPTION_PATTERNS = [
     ]
 ]
 
+# --- RESONANCE / FREQUENCY DETECTION ---
+
+RE_FREQUENCY = re.compile(
+    r"(\d+(?:\.\d+)?)\s*(?:hz|hertz)",
+    re.IGNORECASE,
+)
+
+RE_RESONANCE_KEYWORDS = re.compile(
+    r"\b(?:resonan(?:ce|t)|cymati(?:c|cs)|chladni|nodal|standing\s+wave|harmonic|"
+    r"vibrat(?:e|ion|ional)|frequenc(?:y|ies)|acoustic|waveform|oscillat(?:e|ion)|"
+    r"eigenfrequen(?:cy|cies)|anti[-\s]?node|amplitude)\b",
+    re.IGNORECASE,
+)
+
+
+class ResonanceDetector:
+    """Scan agent utterances for frequency/resonance discussion.
+
+    Maintains a small rolling window of recently mentioned frequencies so
+    that ``consensus_stability`` can rise when multiple agents converge on
+    similar values and fall when discussion diverges.
+    """
+
+    _WINDOW_SIZE = 8
+
+    def __init__(self) -> None:
+        self._recent_frequencies: list[float] = []
+        self._last_emitted_freq: float = 0.0
+        self._last_stability: float = 0.0
+
+    def analyze(self, text: str) -> "dict[str, float] | None":
+        """Return a resonance_state payload dict, or *None* if nothing detected."""
+
+        keyword_hits = len(RE_RESONANCE_KEYWORDS.findall(text))
+        freq_matches = RE_FREQUENCY.findall(text)
+
+        if keyword_hits == 0 and not freq_matches:
+            return None
+
+        # Extract the dominant mentioned frequency (last one wins).
+        if freq_matches:
+            target_freq = float(freq_matches[-1])
+        elif self._recent_frequencies:
+            target_freq = self._recent_frequencies[-1]
+        else:
+            target_freq = 432.0  # sensible acoustic default
+
+        # Track recent frequencies for stability calculation.
+        self._recent_frequencies.append(target_freq)
+        if len(self._recent_frequencies) > self._WINDOW_SIZE:
+            self._recent_frequencies = self._recent_frequencies[-self._WINDOW_SIZE:]
+
+        # Amplitude: more keyword hits → stronger visual effect (capped at 1).
+        amplitude = min(1.0, 0.25 + keyword_hits * 0.15)
+
+        # Consensus stability: how tightly recent frequencies cluster.
+        stability = self._compute_stability()
+
+        self._last_emitted_freq = target_freq
+        self._last_stability = stability
+
+        return {
+            "target_frequency": round(target_freq, 2),
+            "amplitude": round(amplitude, 3),
+            "consensus_stability": round(stability, 3),
+        }
+
+    def _compute_stability(self) -> float:
+        n = len(self._recent_frequencies)
+        if n < 2:
+            return 0.5
+        mean = sum(self._recent_frequencies) / n
+        if mean == 0.0:
+            return 1.0
+        variance = sum((f - mean) ** 2 for f in self._recent_frequencies) / n
+        cv = (variance ** 0.5) / mean  # coefficient of variation
+        # Map CV → stability: cv=0 → 1.0, cv≥0.5 → 0.0
+        return max(0.0, min(1.0, 1.0 - cv * 2.0))
+
 
 def sanitize_text(text: str) -> str:
     """Sanitize external content to prevent prompt injection and control token attacks"""
@@ -1657,6 +1736,7 @@ class RainLabOrchestrator:
         self.visual_event_server = VisualEventServer(config)
         self.visual_conversation_id: Optional[str] = None
         self.visual_conversation_active = False
+        self.resonance_detector = ResonanceDetector()
         self.tts_audio_dir = Path(config.library_path) / config.tts_audio_dir
         if self.config.export_tts_audio:
             self.tts_audio_dir.mkdir(parents=True, exist_ok=True)
@@ -2145,6 +2225,17 @@ class RainLabOrchestrator:
                     "audio": audio_payload,
                 }
             )
+
+            # Emit resonance_state when agents discuss frequencies/acoustics
+            resonance = self.resonance_detector.analyze(clean_response)
+            if resonance is not None:
+                self._emit_visual_event(
+                    {
+                        "type": "resonance_state",
+                        "conversation_id": self.visual_conversation_id or "",
+                        **resonance,
+                    }
+                )
 
             self.voice_engine.speak(
                 spoken_text,


### PR DESCRIPTION
## Summary

- **Base branch target:** `dev`
- **Problem:** Agent discussions about acoustic frequencies, resonance, and cymatic patterns lack visual feedback in the Godot client.
- **Why it matters:** Resonance and frequency discussions are thematically important to the meeting chat; visual representation of Chladni patterns and nodal lines enhances immersion and makes consensus-building on frequency values tangible.
- **What changed:**
  - Added `ResonanceDetector` class to scan agent utterances for frequency mentions and resonance keywords, tracking consensus stability via a rolling window of recent frequencies.
  - Implemented `cymatics_overlay.gdshader` — a Godot shader that renders animated Chladni plate patterns driven by target frequency, amplitude, and consensus stability.
  - Extended `BackgroundPainter` to manage a cymatics overlay layer with smooth interpolation of resonance uniforms.
  - Wired `scene_orchestrator.gd` to handle incoming `resonance_state` events and apply them to the background painter.
  - Updated `NEUTRAL_EVENT_CONTRACT.md` to document the new `resonance_state` event type.
  - Added demo events in `demo_events.json` showcasing resonance state transitions during a frequency discussion.
- **What did not change:**
  - Core agent logic, conversation flow, or TTS/audio handling.
  - Existing visual themes or gradient system.
  - Event routing or WebSocket infrastructure.

## Label Snapshot

- **Risk label:** `risk: low`
- **Size label:** `size: M`
- **Scope labels:** `runtime, observability`
- **Module labels:** `godot: visualization, python: detection`
- **Contributor tier label:** (auto-managed)
- **Auto-label corrections:** None

## Change Metadata

- **Change type:** `feature`
- **Primary scope:** `runtime` (agent utterance analysis + visual event emission)

## Linked Issue

- Closes: (none specified)
- Related: (none specified)

## Validation Evidence

- No Rust/Cargo validation required (Python + GDScript changes only).
- GDScript syntax is validated by Godot editor on load.
- Demo events JSON is well-formed and matches contract schema.
- Shader compiles and runs in Godot 4.x.

## Security Impact

- **New permissions/capabilities?** No
- **New external network calls?** No
- **Secrets/tokens handling changed?** No
- **File system access scope changed?** No

## Privacy and Data Hygiene

- **Data-hygiene status:** `pass`
- **Redaction/anonymization notes:** Frequency values and stability metrics are synthetic/derived; no PII introduced.
- **Neutral wording confirmation:** All terminology is technical (frequency, resonance, Chladni, nodal lines); no identity-like wording.

## Compatibility / Migration

- **Backward compatible?** Yes — new event type is optional; clients without cymatics support simply ignore `resonance_state` events.
- **Config/env changes?** No
- **Migration needed?** No

## i18n Follow-Through

- **i18n follow-through triggered?** No (no user-facing strings; technical documentation only).

## Human Verification

- **Verified scenarios:**
  - Shader renders correctly with varying frequency, amplitude, and stability values.
  - Demo events trigger resonance state updates and visual transitions.
  - Smooth interpolation of uniforms prevents jarring visual jumps.
  - Frequency detection regex correctly identifies Hz mentions and resonance keywords.
  - Stability calculation (coefficient of variation) produces expected 0.0–1.0 range.

- **Edge cases checked:**
  - Zero amplitude → overlay fully transparent (no rendering cost).
  - Single frequency in window → stability defaults to 0.5.
  - High consensus (tight frequency clustering) → stable, symmetric pattern.
  - Low consensus (divergent frequencies) → jittery, wobbling pattern.

- **What was not verified:**
  - Performance under sustained high-frequency updates (expected to be negligible; shader is simple).
  - Interaction with custom theme cymatics colors (basic integration tested; edge cases deferred).

## Side Effects / Blast

https://claude.ai/code/session_015BFCKC8euWR5p6hmffi5jD
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
