### PR TITLE
Add CI/CD workflow status badges to all README locales

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -1,5 +1,12 @@
 # Point d’entrée de la documentation R.A.I.N. Lab (FR)
 
+<p align="center">
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/ci.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/tests.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml/badge.svg?branch=main" alt="Docs" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml/badge.svg?branch=main" alt="Security Audit" /></a>
+</p>
+
 > Cette page est le point d’entrée français, aligné sur le README principal et l’architecture docs.
 
 ## Navigation

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,12 @@
 # R.A.I.N. Lab ドキュメント入口（日本語）
 
+<p align="center">
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/ci.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/tests.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml/badge.svg?branch=main" alt="Docs" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml/badge.svg?branch=main" alt="Security Audit" /></a>
+</p>
+
 > このページは日本語向けのリポジトリ入口です。README と docs ハブ構成に合わせています。
 
 ## ナビゲーション

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ hero:
 </p>
 
 <p align="center">
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/ci.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/tests.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml/badge.svg?branch=main" alt="Docs" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml/badge.svg?branch=main" alt="Security Audit" /></a>
+</p>
+
+<p align="center">
   <a href="https://deepwiki.com/topherchris420/james_library"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
 </p>
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,5 +1,12 @@
 # Точка входа в документацию R.A.I.N. Lab (RU)
 
+<p align="center">
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/ci.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/tests.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml/badge.svg?branch=main" alt="Docs" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml/badge.svg?branch=main" alt="Security Audit" /></a>
+</p>
+
 > Эта страница — русскоязычная точка входа, синхронизированная с основной структурой README и docs.
 
 ## Навигация

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,5 +1,12 @@
 # Điểm vào tài liệu R.A.I.N. Lab (VI)
 
+<p align="center">
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/ci.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/tests.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml/badge.svg?branch=main" alt="Docs" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml/badge.svg?branch=main" alt="Security Audit" /></a>
+</p>
+
 > Trang này là điểm vào tiếng Việt, đồng bộ với README chính và cấu trúc docs.
 
 ## Điều hướng

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,12 @@
 # R.A.I.N. Lab 文档入口（简体中文）
 
+<p align="center">
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/ci.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/tests.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/deploy-docs.yml/badge.svg?branch=main" alt="Docs" /></a>
+  <a href="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml"><img src="https://github.com/topherchris420/james_library/actions/workflows/sec-audit.yml/badge.svg?branch=main" alt="Security Audit" /></a>
+</p>
+
 > 本页是仓库的中文入口页，对齐主 README 与文档中心的信息架构。
 
 ## 导航


### PR DESCRIPTION
## Summary

- **Base branch target**: `dev`
- **Problem**: README files across all supported locales (main, French, Japanese, Russian, Vietnamese, Simplified Chinese) lack visibility into CI/CD pipeline status
- **Why it matters**: Status badges provide quick visual feedback on build health, test coverage, documentation deployment, and security audit status—improving contributor confidence and project transparency
- **What changed**: Added centered badge section displaying CI, Tests, Docs deployment, and Security Audit workflow status to all six README variants
- **What did not change**: No functional code changes; documentation-only updates to badge display

## Label Snapshot

- **Risk label**: `risk: low`
- **Size label**: `size: XS`
- **Scope labels**: `docs`
- **Module labels**: N/A
- **Contributor tier label**: Auto-managed
- **Auto-label corrections**: None

## Change Metadata

- **Change type**: `docs`
- **Primary scope**: `docs`

## Linked Issue

- Closes: (none specified)
- Related: (none specified)

## Validation Evidence

- No code compilation or testing required (documentation-only change)
- Badge URLs reference valid GitHub Actions workflows (`ci.yml`, `tests.yml`, `deploy-docs.yml`, `sec-audit.yml`)
- HTML/Markdown syntax verified for consistency across all six README files

## Security Impact

- **New permissions/capabilities?** No
- **New external network calls?** No (badges are static image references to GitHub Actions)
- **Secrets/tokens handling changed?** No
- **File system access scope changed?** No

## Privacy and Data Hygiene

- **Data-hygiene status**: `pass`
- **Redaction/anonymization notes**: N/A
- **Neutral wording confirmation**: Badge labels use standard CI/CD terminology (`CI`, `Tests`, `Docs`, `Security Audit`)

## Compatibility / Migration

- **Backward compatible?** Yes
- **Config/env changes?** No
- **Migration needed?** No

## i18n Follow-Through

- **i18n follow-through triggered?** Yes
- **Locale navigation parity updated?** Yes—badges added consistently to `README.md`, `README.fr.md`, `README.ja.md`, `README.ru.md`, `README.vi.md`, and `README.zh-CN.md`
- **Localized runtime-contract docs updated?** N/A (badge-only change, no contract/reference docs affected)
- **Vietnamese canonical docs synced?** N/A

## Human Verification

- **Verified scenarios**: Badge HTML structure consistent across all six README files; badge URLs point to correct workflow files on `main` branch
- **Edge cases checked**: N/A
- **What was not verified**: Live badge rendering (depends on GitHub Actions workflow execution)

## Side Effects / Blast Radius

- **Affected subsystems/workflows**: Documentation display only; no runtime or CI/CD logic changes
- **Potential unintended effects**: None
- **Guardrails/monitoring**: Badges will automatically update as GitHub Actions workflows execute

## Rollback Plan

- **Fast rollback command/path**: `git revert <commit-hash>` or remove the badge `<p>` blocks from all six README files
- **Feature flags or config toggles**: N/A
- **Observable failure symptoms**: Badges would fail to render if GitHub Actions workflows are deleted or renamed

## Risks and Mitigations

- **Risk**: Badge URLs become stale if workflow files are renamed or moved
  - **Mitigation**: Update badge URLs in all six README files when workflows are refactored; consider documenting workflow file locations in contributing guidelines

https://claude.ai/code/session_01VPPgENsi2rNF5FwRzH7G1e
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
