### PR TITLE
Replace unwrap() calls with proper error handling throughout codebase

### DIFF
--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -220,10 +220,12 @@ pub(crate) fn build_native_assistant_history(
     });
 
     if let Some(rc) = reasoning_content {
-        obj.as_object_mut().unwrap().insert(
-            "reasoning_content".to_string(),
-            serde_json::Value::String(rc.to_string()),
-        );
+        if let Some(map) = obj.as_object_mut() {
+            map.insert(
+                "reasoning_content".to_string(),
+                serde_json::Value::String(rc.to_string()),
+            );
+        }
     }
 
     obj.to_string()
@@ -257,10 +259,12 @@ pub(crate) fn build_native_assistant_history_from_parsed_calls(
     });
 
     if let Some(rc) = reasoning_content {
-        obj.as_object_mut().unwrap().insert(
-            "reasoning_content".to_string(),
-            serde_json::Value::String(rc.to_string()),
-        );
+        if let Some(map) = obj.as_object_mut() {
+            map.insert(
+                "reasoning_content".to_string(),
+                serde_json::Value::String(rc.to_string()),
+            );
+        }
     }
 
     Some(obj.to_string())

--- a/src/agent/tool_call_parsing.rs
+++ b/src/agent/tool_call_parsing.rs
@@ -181,8 +181,14 @@ fn extract_xml_pairs(input: &str) -> Vec<(&str, &str)> {
     let mut results = Vec::new();
     let mut search_start = 0;
     while let Some(open_cap) = XML_OPEN_TAG_RE.captures(&input[search_start..]) {
-        let full_open = open_cap.get(0).unwrap();
-        let tag_name = open_cap.get(1).unwrap().as_str();
+        let Some(full_open) = open_cap.get(0) else {
+            break;
+        };
+        let Some(tag_match) = open_cap.get(1) else {
+            search_start += full_open.end();
+            continue;
+        };
+        let tag_name = tag_match.as_str();
         let open_end = search_start + full_open.end();
 
         let closing_tag = format!("</{tag_name}>");
@@ -1090,7 +1096,9 @@ pub(crate) fn parse_tool_calls(response: &str) -> (String, Vec<ParsedToolCall>) 
         let mut last_end = 0;
 
         for cap in MD_TOOL_CALL_RE.captures_iter(response) {
-            let full_match = cap.get(0).unwrap();
+            let Some(full_match) = cap.get(0) else {
+                continue;
+            };
             let before = &response[last_end..full_match.start()];
             if !before.trim().is_empty() {
                 md_text_parts.push(before.trim().to_string());
@@ -1122,7 +1130,9 @@ pub(crate) fn parse_tool_calls(response: &str) -> (String, Vec<ParsedToolCall>) 
         let mut last_end = 0;
 
         for cap in MD_TOOL_NAME_RE.captures_iter(response) {
-            let full_match = cap.get(0).unwrap();
+            let Some(full_match) = cap.get(0) else {
+                continue;
+            };
             let before = &response[last_end..full_match.start()];
             if !before.trim().is_empty() {
                 md_text_parts.push(before.trim().to_string());

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -474,7 +474,7 @@ fn refresh_lock_for_profile(profile_id: &str) -> Arc<tokio::sync::Mutex<()>> {
     static LOCKS: OnceLock<Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>> = OnceLock::new();
 
     let table = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
-    let mut guard = table.lock().expect("refresh lock table poisoned");
+    let mut guard = table.lock().unwrap_or_else(|e| e.into_inner());
 
     guard
         .entry(profile_id.to_string())

--- a/src/channels/mattermost.rs
+++ b/src/channels/mattermost.rs
@@ -104,10 +104,12 @@ impl Channel for MattermostChannel {
         });
 
         if let Some(root) = root_id {
-            body_map.as_object_mut().unwrap().insert(
-                "root_id".to_string(),
-                serde_json::Value::String(root.to_string()),
-            );
+            if let Some(obj) = body_map.as_object_mut() {
+                obj.insert(
+                    "root_id".to_string(),
+                    serde_json::Value::String(root.to_string()),
+                );
+            }
         }
 
         let resp = self
@@ -236,9 +238,9 @@ impl Channel for MattermostChannel {
             loop {
                 let mut body = serde_json::json!({ "channel_id": channel_id });
                 if let Some(ref pid) = parent_id {
-                    body.as_object_mut()
-                        .unwrap()
-                        .insert("parent_id".to_string(), serde_json::json!(pid));
+                    if let Some(obj) = body.as_object_mut() {
+                        obj.insert("parent_id".to_string(), serde_json::json!(pid));
+                    }
                 }
 
                 if let Ok(r) = client

--- a/src/channels/signal.rs
+++ b/src/channels/signal.rs
@@ -90,10 +90,10 @@ impl SignalChannel {
         }
     }
 
-    fn http_client(&self) -> Client {
+    fn http_client(&self) -> anyhow::Result<Client> {
         let builder = Client::builder().connect_timeout(Duration::from_secs(10));
         let builder = crate::config::apply_runtime_proxy_to_builder(builder, "channel.signal");
-        builder.build().expect("Signal HTTP client should build")
+        Ok(builder.build()?)
     }
 
     /// Effective sender: prefer `sourceNumber` (E.164), fall back to `source`.
@@ -184,7 +184,7 @@ impl SignalChannel {
         });
 
         let resp = self
-            .http_client()
+            .http_client()?
             .post(&url)
             .timeout(Duration::from_secs(30))
             .header("Content-Type", "application/json")
@@ -308,7 +308,7 @@ impl Channel for SignalChannel {
 
         loop {
             let resp = self
-                .http_client()
+                .http_client()?
                 .get(url.clone())
                 .header("Accept", "text/event-stream")
                 .send()
@@ -417,8 +417,10 @@ impl Channel for SignalChannel {
 
     async fn health_check(&self) -> bool {
         let url = format!("{}/api/v1/check", self.http_url);
-        let Ok(resp) = self
-            .http_client()
+        let Ok(client) = self.http_client() else {
+            return false;
+        };
+        let Ok(resp) = client
             .get(&url)
             .timeout(Duration::from_secs(10))
             .send()

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -1477,7 +1477,9 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                     }
                 }
                 // Default: escape HTML entities
-                let ch = line[i..].chars().next().unwrap();
+                let Some(ch) = line[i..].chars().next() else {
+                    break;
+                };
                 match ch {
                     '<' => line_out.push_str("&lt;"),
                     '>' => line_out.push_str("&gt;"),

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -601,7 +601,7 @@ fn check_config_semantics(config: &Config, items: &mut Vec<DiagItem>) {
     let mut agent_names: Vec<_> = config.agents.keys().collect();
     agent_names.sort();
     for name in agent_names {
-        let agent = config.agents.get(name).unwrap();
+        let Some(agent) = config.agents.get(name) else { continue };
         if let Some(reason) = provider_validation_error(&agent.provider) {
             items.push(DiagItem::warn(
                 cat,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1648,7 +1648,7 @@ mod tests {
 
     #[tokio::test]
     async fn metrics_endpoint_renders_prometheus_output() {
-        let prom = Arc::new(crate::observability::PrometheusObserver::new());
+        let prom = Arc::new(crate::observability::PrometheusObserver::new().unwrap());
         crate::observability::Observer::record_event(
             prom.as_ref(),
             &crate::observability::ObserverEvent::HeartbeatTick,

--- a/src/hooks/builtin/command_logger.rs
+++ b/src/hooks/builtin/command_logger.rs
@@ -48,7 +48,7 @@ impl HookHandler for CommandLoggerHook {
             result.success,
         );
         tracing::info!(hook = "command-logger", "{}", entry);
-        self.log.lock().unwrap().push(entry);
+        self.log.lock().unwrap_or_else(|e| e.into_inner()).push(entry);
     }
 }
 

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -786,7 +786,7 @@ pub fn aieos_to_system_prompt(identity: &AieosIdentity) -> String {
                 let mut sorted_keys: Vec<_> = matrix.keys().collect();
                 sorted_keys.sort();
                 for trait_name in sorted_keys {
-                    let weight = matrix.get(trait_name).unwrap();
+                    let Some(weight) = matrix.get(trait_name) else { continue };
                     let _ = writeln!(prompt, "- {trait_name}: {weight:.2}");
                 }
             }
@@ -958,7 +958,7 @@ pub fn aieos_to_system_prompt(identity: &AieosIdentity) -> String {
                 let mut sorted_keys: Vec<_> = favorites.keys().collect();
                 sorted_keys.sort();
                 for category in sorted_keys {
-                    let value = favorites.get(category).unwrap();
+                    let Some(value) = favorites.get(category) else { continue };
                     let _ = writeln!(prompt, "- {category}: {value}");
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -688,7 +688,7 @@ async fn main() -> Result<()> {
         )
         .finish();
 
-    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+    tracing::subscriber::set_global_default(subscriber).context("setting default subscriber failed")?;
 
     // Onboard runs quick setup by default, or the interactive wizard with --interactive.
     // The onboard wizard uses reqwest::blocking internally, which creates its own
@@ -1028,7 +1028,7 @@ async fn main() -> Result<()> {
                 let schema = schemars::schema_for!(config::Config);
                 println!(
                     "{}",
-                    serde_json::to_string_pretty(&schema).expect("failed to serialize JSON Schema")
+                    serde_json::to_string_pretty(&schema).context("failed to serialize JSON Schema")?
                 );
                 Ok(())
             }

--- a/src/memory/snapshot.rs
+++ b/src/memory/snapshot.rs
@@ -64,17 +64,16 @@ pub fn export_snapshot(workspace_dir: &Path) -> Result<usize> {
     output.push_str(SNAPSHOT_HEADER);
 
     let now = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
-    write!(output, "**Last exported:** {now}\n\n").unwrap();
-    write!(output, "**Total core memories:** {}\n\n---\n\n", rows.len()).unwrap();
+    let _ = write!(output, "**Last exported:** {now}\n\n");
+    let _ = write!(output, "**Total core memories:** {}\n\n---\n\n", rows.len());
 
     for (key, content, _category, created_at, updated_at) in &rows {
-        write!(output, "### 🔑 `{key}`\n\n").unwrap();
-        write!(output, "{content}\n\n").unwrap();
-        write!(
+        let _ = write!(output, "### 🔑 `{key}`\n\n");
+        let _ = write!(output, "{content}\n\n");
+        let _ = write!(
             output,
             "*Created: {created_at} | Updated: {updated_at}*\n\n---\n\n"
-        )
-        .unwrap();
+        );
     }
 
     let snapshot_path = snapshot_path(workspace_dir);

--- a/src/memory/sqlite.rs
+++ b/src/memory/sqlite.rs
@@ -213,11 +213,7 @@ impl SqliteMemory {
         // First 8 bytes → 16 hex chars, matching previous format length
         format!(
             "{:016x}",
-            u64::from_be_bytes(
-                hash[..8]
-                    .try_into()
-                    .expect("SHA-256 always produces >= 8 bytes")
-            )
+            u64::from_be_bytes(hash[..8].try_into().unwrap_or_default())
         )
     }
 

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -26,7 +26,13 @@ use crate::config::ObservabilityConfig;
 pub fn create_observer(config: &ObservabilityConfig) -> Box<dyn Observer> {
     match config.backend.as_str() {
         "log" => Box::new(LogObserver::new()),
-        "prometheus" => Box::new(PrometheusObserver::new()),
+        "prometheus" => match PrometheusObserver::new() {
+            Ok(obs) => Box::new(obs),
+            Err(e) => {
+                tracing::error!("Failed to create Prometheus observer: {e}. Falling back to noop.");
+                Box::new(NoopObserver)
+            }
+        },
         "otel" | "opentelemetry" | "otlp" => {
             #[cfg(feature = "observability-otel")]
             match OtelObserver::new(

--- a/src/observability/prometheus.rs
+++ b/src/observability/prometheus.rs
@@ -29,26 +29,23 @@ pub struct PrometheusObserver {
 }
 
 impl PrometheusObserver {
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self, prometheus::Error> {
         let registry = Registry::new();
 
         let agent_starts = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_agent_starts_total", "Total agent invocations"),
             &["provider", "model"],
-        )
-        .expect("valid metric");
+        )?;
 
         let llm_requests = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_llm_requests_total", "Total LLM provider requests"),
             &["provider", "model", "success"],
-        )
-        .expect("valid metric");
+        )?;
 
         let tokens_input_total = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_tokens_input_total", "Total input tokens consumed"),
             &["provider", "model"],
-        )
-        .expect("valid metric");
+        )?;
 
         let tokens_output_total = IntCounterVec::new(
             prometheus::Opts::new(
@@ -56,30 +53,25 @@ impl PrometheusObserver {
                 "Total output tokens consumed",
             ),
             &["provider", "model"],
-        )
-        .expect("valid metric");
+        )?;
 
         let tool_calls = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_tool_calls_total", "Total tool calls"),
             &["tool", "success"],
-        )
-        .expect("valid metric");
+        )?;
 
         let channel_messages = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_channel_messages_total", "Total channel messages"),
             &["channel", "direction"],
-        )
-        .expect("valid metric");
+        )?;
 
         let heartbeat_ticks =
-            prometheus::IntCounter::new("zeroclaw_heartbeat_ticks_total", "Total heartbeat ticks")
-                .expect("valid metric");
+            prometheus::IntCounter::new("zeroclaw_heartbeat_ticks_total", "Total heartbeat ticks")?;
 
         let errors = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_errors_total", "Total errors by component"),
             &["component"],
-        )
-        .expect("valid metric");
+        )?;
 
         let agent_duration = HistogramVec::new(
             HistogramOpts::new(
@@ -88,8 +80,7 @@ impl PrometheusObserver {
             )
             .buckets(vec![0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0]),
             &["provider", "model"],
-        )
-        .expect("valid metric");
+        )?;
 
         let tool_duration = HistogramVec::new(
             HistogramOpts::new(
@@ -98,8 +89,7 @@ impl PrometheusObserver {
             )
             .buckets(vec![0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0]),
             &["tool"],
-        )
-        .expect("valid metric");
+        )?;
 
         let request_latency = Histogram::with_opts(
             HistogramOpts::new(
@@ -107,26 +97,22 @@ impl PrometheusObserver {
                 "Request latency in seconds",
             )
             .buckets(vec![0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]),
-        )
-        .expect("valid metric");
+        )?;
 
         let tokens_used = prometheus::IntGauge::new(
             "zeroclaw_tokens_used_last",
             "Tokens used in the last request",
-        )
-        .expect("valid metric");
+        )?;
 
         let active_sessions = GaugeVec::new(
             prometheus::Opts::new("zeroclaw_active_sessions", "Number of active sessions"),
             &[],
-        )
-        .expect("valid metric");
+        )?;
 
         let queue_depth = GaugeVec::new(
             prometheus::Opts::new("zeroclaw_queue_depth", "Message queue depth"),
             &[],
-        )
-        .expect("valid metric");
+        )?;
 
         // Register all metrics
         registry.register(Box::new(agent_starts.clone())).ok();
@@ -146,7 +132,7 @@ impl PrometheusObserver {
         registry.register(Box::new(active_sessions.clone())).ok();
         registry.register(Box::new(queue_depth.clone())).ok();
 
-        Self {
+        Ok(Self {
             registry,
             agent_starts,
             llm_requests,
@@ -162,7 +148,7 @@ impl PrometheusObserver {
             tokens_used,
             active_sessions,
             queue_depth,
-        }
+        })
     }
 
     /// Encode all registered metrics into Prometheus text exposition format.

--- a/src/peripherals/nucleo_flash.rs
+++ b/src/peripherals/nucleo_flash.rs
@@ -63,7 +63,7 @@ pub fn flash_nucleo_firmware() -> Result<()> {
 
     println!("Flashing to Nucleo-F401RE (connect via USB)...");
     let flash = Command::new("probe-rs")
-        .args(["run", "--chip", CHIP, elf_path.to_str().unwrap()])
+        .args(["run", "--chip", CHIP, elf_path.to_str().context("ELF path contains invalid UTF-8")?])
         .output()
         .context("probe-rs run failed")?;
 

--- a/src/peripherals/uno_q_setup.rs
+++ b/src/peripherals/uno_q_setup.rs
@@ -50,7 +50,7 @@ fn deploy_remote(host: &str, bridge_dir: &std::path::Path) -> Result<()> {
     let status = Command::new("scp")
         .args([
             "-r",
-            bridge_dir.to_str().unwrap(),
+            bridge_dir.to_str().context("bridge directory path contains invalid UTF-8")?,
             &format!("{}:~/ArduinoApps/", ssh_target),
         ])
         .status()
@@ -98,7 +98,7 @@ fn deploy_local(bridge_dir: Option<&std::path::Path>) -> Result<()> {
 
     println!("Starting Bridge app...");
     let status = Command::new("arduino-app-cli")
-        .args(["app", "start", dest_dir.to_str().unwrap()])
+        .args(["app", "start", dest_dir.to_str().context("destination directory path contains invalid UTF-8")?])
         .status()
         .context("arduino-app-cli start failed")?;
     if !status.success() {

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -1032,7 +1032,8 @@ impl GeminiProvider {
                             (token, proj)
                         }
                         GeminiAuth::ManagedOAuth => {
-                            let auth_service = self.auth_service.as_ref().unwrap();
+                            let auth_service = self.auth_service.as_ref()
+                                .ok_or_else(|| anyhow::anyhow!("ManagedOAuth requires auth_service"))?;
                             let token = auth_service
                                 .get_valid_gemini_access_token(
                                     self.auth_profile_override.as_deref(),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1014,7 +1014,7 @@ fn create_provider_with_url_and_options(
         ))),
         name if moonshot_base_url(name).is_some() => Ok(Box::new(OpenAiCompatibleProvider::new(
             "Moonshot",
-            moonshot_base_url(name).expect("checked in guard"),
+            moonshot_base_url(name).ok_or_else(|| anyhow::anyhow!("moonshot base URL missing"))?,
             key,
             AuthStyle::Bearer,
         ))),
@@ -1035,14 +1035,14 @@ fn create_provider_with_url_and_options(
         ))),
         name if zai_base_url(name).is_some() => Ok(Box::new(OpenAiCompatibleProvider::new(
             "Z.AI",
-            zai_base_url(name).expect("checked in guard"),
+            zai_base_url(name).ok_or_else(|| anyhow::anyhow!("Z.AI base URL missing"))?,
             key,
             AuthStyle::Bearer,
         ))),
         name if glm_base_url(name).is_some() => {
             Ok(Box::new(OpenAiCompatibleProvider::new_no_responses_fallback(
                 "GLM",
-                glm_base_url(name).expect("checked in guard"),
+                glm_base_url(name).ok_or_else(|| anyhow::anyhow!("GLM base URL missing"))?,
                 key,
                 AuthStyle::Bearer,
             )))
@@ -1050,7 +1050,7 @@ fn create_provider_with_url_and_options(
         name if minimax_base_url(name).is_some() => Ok(Box::new(
             OpenAiCompatibleProvider::new_merge_system_into_user(
                 "MiniMax",
-                minimax_base_url(name).expect("checked in guard"),
+                minimax_base_url(name).ok_or_else(|| anyhow::anyhow!("MiniMax base URL missing"))?,
                 key,
                 AuthStyle::Bearer,
             )
@@ -1085,7 +1085,7 @@ fn create_provider_with_url_and_options(
         ))),
         name if qwen_base_url(name).is_some() => Ok(Box::new(OpenAiCompatibleProvider::new_with_vision(
             "Qwen",
-            qwen_base_url(name).expect("checked in guard"),
+            qwen_base_url(name).ok_or_else(|| anyhow::anyhow!("Qwen base URL missing"))?,
             key,
             AuthStyle::Bearer,
             true,

--- a/src/security/pairing.rs
+++ b/src/security/pairing.rs
@@ -190,9 +190,13 @@ impl PairingGuard {
         // TODO: make this function the main one without spawning a task
         let handle = tokio::task::spawn_blocking(move || this.try_pair_blocking(&code, &client_id));
 
-        handle
-            .await
-            .expect("failed to spawn blocking task this should not happen")
+        match handle.await {
+            Ok(result) => result,
+            Err(e) => {
+                tracing::error!("Pairing task failed unexpectedly: {e}");
+                Ok(None)
+            }
+        }
     }
 
     /// Check if a bearer token is valid (compares against stored hashes).

--- a/src/tools/git_operations.rs
+++ b/src/tools/git_operations.rs
@@ -500,12 +500,12 @@ impl Tool for GitOperationsTool {
             // Try to find .git in parent directories
             let mut current_dir = self.workspace_dir.as_path();
             let mut found_git = false;
-            while current_dir.parent().is_some() {
+            while let Some(parent) = current_dir.parent() {
                 if current_dir.join(".git").exists() {
                     found_git = true;
                     break;
                 }
-                current_dir = current_dir.parent().unwrap();
+                current_dir = parent;
             }
 
             if !found_git {

--- a/src/tools/hardware_memory_read.rs
+++ b/src/tools/hardware_memory_read.rs
@@ -78,17 +78,19 @@ impl Tool for HardwareMemoryReadTool {
             .or_else(|| self.boards.first().cloned())
             .unwrap_or_else(|| "nucleo-f401re".into());
 
-        let chip = Self::chip_for_board(&board);
-        if chip.is_none() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some(format!(
-                    "Memory read only supports nucleo-f401re, nucleo-f411re. Got: {}",
-                    board
-                )),
-            });
-        }
+        let chip = match Self::chip_for_board(&board) {
+            Some(c) => c,
+            None => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "Memory read only supports nucleo-f401re, nucleo-f411re. Got: {}",
+                        board
+                    )),
+                });
+            }
+        };
 
         let address_str = args
             .get("address")
@@ -103,7 +105,7 @@ impl Tool for HardwareMemoryReadTool {
 
         #[cfg(feature = "probe")]
         {
-            match probe_read_memory(chip.unwrap(), _address, _length) {
+            match probe_read_memory(chip, _address, _length) {
                 Ok(output) => {
                     return Ok(ToolResult {
                         success: true,


### PR DESCRIPTION
## Summary

- Base branch target: `dev`
- Problem: Codebase contains numerous `unwrap()` and `.expect()` calls that can panic at runtime, reducing robustness and making error handling inconsistent
- Why it matters: Proper error propagation and graceful degradation improve reliability and observability; panics are unrecoverable and hide root causes
- What changed: Systematically replaced `unwrap()` and `.expect()` calls with `?` operator, `match` expressions, `if let`, and `.ok_or_else()` patterns across 15+ files
- What did **not** change: Core business logic, public API signatures (except `PrometheusObserver::new()` which now returns `Result`), or test infrastructure

## Label Snapshot

- Risk label: `risk: low`
- Size label: `size: L`
- Scope labels: `observability,provider,channel,memory,security,tool,core,gateway,auth,doctor`
- Module labels: `observability: prometheus`, `channel: mattermost,signal,telegram`, `provider: gemini,moonshot,zai,glm,minimax,qwen`, `tool: hardware_memory_read,git_operations`, `memory: snapshot,sqlite`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect: None noted

## Change Metadata

- Change type: `refactor`
- Primary scope: `multi` (observability, provider, channel, memory, security, tool)

## Linked Issue

- Closes: (none explicitly linked; this is a general robustness improvement)
- Related: (general code quality initiative)

## Validation Evidence

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided: Code compiles without warnings; all existing tests pass (no new test failures introduced)
- If any command is intentionally skipped: None

## Security Impact

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No changes to data handling
- Neutral wording confirmation: No identity-like wording changes

## Compatibility / Migration

- Backward compatible? `No` (PrometheusObserver::new() now returns Result; callers must handle)
- Config/env changes? `No`
- Migration needed? `Yes` (minimal: one call site in observability/mod.rs updated to handle Result)
- If yes, exact upgrade steps: Update any direct calls to `PrometheusObserver::new()` to handle the `Result` type; fallback to `NoopObserver` on error (pattern shown in observability/mod.rs)

## i18n Follow-Through

- i18n follow-through triggered? `No`
- If `Yes`, locale navigation parity updated: N/A
- If `Yes`, localized runtime-contract docs updated: N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: No user-facing strings or documentation changes

## Human Verification

What was personally validated beyond CI:

- Verified scenarios:
  - PrometheusObserver initialization with error fallback to NoopObserver
  - Signal channel HTTP client creation error handling
  - XML tag extraction with proper None checks
  - JSON object mutation with safe `as_object_mut()` checks
  - File path UTF-8 validation in command arguments
  
- Edge cases checked:
  - Regex capture groups that may not exist (XML parsing, markdown tool calls)
  - Mutex poisoning recovery (auth locks, hook logs)
  - Optional parent directory traversal (git operations)
  - Missing auth service in Gemini provider (ManagedOAuth path)
  
- What was not verified: Runtime behavior in production environments (CI validation sufficient for refactor)

## Side Effects / Blast Radius

- Affected subsystems/workflows:
  - Prometheus observer initialization

https://claude.ai/code/session_01Ujh3Hty6zZApJrWs9m44f6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
