### PR TITLE
orchestrator: richer experiment runner, scoring and reporting; add chat `--temp`/`--max-tokens` flags; docs and tests

### DIFF
--- a/docs/commands-reference.fr.md
+++ b/docs/commands-reference.fr.md
@@ -10,6 +10,7 @@ Modes principaux:
 
 - `--mode first-run`
 - `--mode chat --topic "..."`
+- `--mode chat --topic "..." --temp 0.85 --max-tokens 320` pour des sorties d'expérimentation plus exploratoires
 - `--mode validate`
 - `--mode status`
 - `--mode models`

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -10,6 +10,7 @@ Core modes:
 
 - `--mode first-run`
 - `--mode chat --topic "..."`
+- `--mode chat --topic "..." --temp 0.85 --max-tokens 320` for more exploratory experiment output
 - `--mode validate`
 - `--mode status`
 - `--mode models`

--- a/docs/i18n/vi/commands-reference.md
+++ b/docs/i18n/vi/commands-reference.md
@@ -10,6 +10,7 @@ Chế độ thường dùng:
 
 - `--mode first-run`
 - `--mode chat --topic "..."`
+- `--mode chat --topic "..." --temp 0.85 --max-tokens 320` để tạo đầu ra thử nghiệm giàu khám phá hơn
 - `--mode validate`
 - `--mode status`
 - `--mode models`

--- a/lab/orchestrator.py
+++ b/lab/orchestrator.py
@@ -143,7 +143,7 @@ def evaluate_results(outputs):
     else:
         summary = (
             f"{success_count}/{total_runs} experiment runs succeeded. "
-            f"Best run: {best_run['config']}. Preview: {best_run['stdout_preview']}"
+            f"Best run: {format_config_label(best_run['config'])}. Preview: {best_run['stdout_preview']}"
         )
 
     return {

--- a/lab/orchestrator.py
+++ b/lab/orchestrator.py
@@ -1,9 +1,11 @@
 import datetime
 import json
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
+from statistics import mean
 
 from generate_experiments import generate
 
@@ -12,38 +14,196 @@ LAB_DIR = ROOT / "lab"
 LOGS = LAB_DIR / "logs"
 LOGS.mkdir(parents=True, exist_ok=True)
 
+DEFAULT_SUMMARY_CHARS = 180
+DEFAULT_PREVIEW_LINES = 3
+
+
+def resolve_experiment_command() -> list[str] | None:
+    configured = os.getenv("LAB_EXPERIMENT_CMD", "").strip()
+    if configured:
+        return shlex.split(configured)
+
+    default_runner = ROOT / "run_experiments.py"
+    if default_runner.exists():
+        return [sys.executable, str(default_runner)]
+
+    return None
+
+
+def format_config_label(config: dict) -> str:
+    if not config:
+        return "default"
+    return ", ".join(f"{key}={value}" for key, value in sorted(config.items()))
+
+
+def preview_text(text: str, max_lines: int = DEFAULT_PREVIEW_LINES, max_chars: int = DEFAULT_SUMMARY_CHARS) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return "(no output)"
+
+    preview = " | ".join(lines[:max_lines])
+    if len(preview) > max_chars:
+        return preview[: max_chars - 1] + "…"
+    return preview
+
+
+def score_run(output: dict) -> int:
+    score = 0
+    if output["returncode"] == 0:
+        score += 100
+    else:
+        score -= 100 + abs(output["returncode"])
+
+    score += min(len(output["stdout"].strip()), 400)
+    score -= min(len(output["stderr"].strip()), 200)
+    return score
+
 
 def run_experiments(config):
-    print(f"Running experiments for config: {config}")
+    config_label = format_config_label(config)
+    print(f"Running experiments for config: {config_label}")
+
+    command = resolve_experiment_command()
+    if command is None:
+        stderr = (
+            "Experiment runner not found. Set LAB_EXPERIMENT_CMD to the command that should execute "
+            "one experiment run."
+        )
+        return {
+            "config": config,
+            "command": None,
+            "returncode": 127,
+            "stdout": "",
+            "stderr": stderr,
+            "duration_s": 0.0,
+            "score": -227,
+            "stdout_preview": "(no output)",
+            "stderr_preview": preview_text(stderr),
+        }
+
+    started = datetime.datetime.now(datetime.timezone.utc)
     result = subprocess.run(
-        [sys.executable, "run_experiments.py"],  # adjust to your actual entrypoint
+        command,
         capture_output=True,
         text=True,
         cwd=ROOT,
         env={**os.environ, "LAB_CONFIG": json.dumps(config)},
     )
-    return {
+    duration_s = (datetime.datetime.now(datetime.timezone.utc) - started).total_seconds()
+
+    output = {
         "config": config,
+        "command": command,
         "returncode": result.returncode,
         "stdout": result.stdout,
         "stderr": result.stderr,
+        "duration_s": round(duration_s, 3),
     }
+    output["score"] = score_run(output)
+    output["stdout_preview"] = preview_text(output["stdout"])
+    output["stderr_preview"] = preview_text(output["stderr"])
+    return output
 
 
 def evaluate_results(outputs):
-    combined_stdout = "\n".join(item["stdout"] for item in outputs)
-    score = len(combined_stdout)
+    total_runs = len(outputs)
+    success_count = sum(1 for item in outputs if item["returncode"] == 0)
+    failure_count = total_runs - success_count
+    ranked_runs = sorted(outputs, key=lambda item: item["score"], reverse=True)
+    best_run = ranked_runs[0] if ranked_runs else None
+    average_score = round(mean(item["score"] for item in outputs), 2) if outputs else 0.0
+    total_stdout_chars = sum(len(item["stdout"]) for item in outputs)
+    total_stderr_chars = sum(len(item["stderr"]) for item in outputs)
+
+    highlights = []
+    for item in ranked_runs:
+        config_label = format_config_label(item["config"])
+        status = "ok" if item["returncode"] == 0 else f"failed ({item['returncode']})"
+        snippet_source = item["stdout_preview"]
+        if snippet_source == "(no output)" and item["stderr_preview"] != "(no output)":
+            snippet_source = item["stderr_preview"]
+        highlights.append(
+            {
+                "config": item["config"],
+                "config_label": config_label,
+                "status": status,
+                "score": item["score"],
+                "duration_s": item["duration_s"],
+                "snippet": snippet_source,
+            }
+        )
+
+    if not ranked_runs:
+        summary = "No experiment runs were produced."
+    elif failure_count == total_runs:
+        summary = (
+            f"{total_runs} experiment runs failed. Top issue from {highlights[0]['config_label']}: "
+            f"{highlights[0]['snippet']}"
+        )
+    else:
+        summary = (
+            f"{success_count}/{total_runs} experiment runs succeeded. "
+            f"Best run: {best_run['config']}. Preview: {best_run['stdout_preview']}"
+        )
+
     return {
-        "score": score,
-        "summary": combined_stdout[:500],
+        "score": average_score,
+        "summary": summary,
+        "total_runs": total_runs,
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "total_stdout_chars": total_stdout_chars,
+        "total_stderr_chars": total_stderr_chars,
+        "best_run": {
+            "config": best_run["config"],
+            "score": best_run["score"],
+            "returncode": best_run["returncode"],
+            "stdout_preview": best_run["stdout_preview"],
+            "stderr_preview": best_run["stderr_preview"],
+        }
+        if best_run
+        else None,
+        "highlights": highlights,
         "runs": [
             {
                 "config": item["config"],
                 "returncode": item["returncode"],
+                "score": item["score"],
+                "duration_s": item["duration_s"],
+                "stdout_preview": item["stdout_preview"],
+                "stderr_preview": item["stderr_preview"],
             }
-            for item in outputs
+            for item in ranked_runs
         ],
     }
+
+
+def format_evaluation_report(evaluation: dict) -> str:
+    lines = [
+        "Experiment evaluation:",
+        (
+            f"- Runs: {evaluation['total_runs']} total | {evaluation['success_count']} succeeded | "
+            f"{evaluation['failure_count']} failed"
+        ),
+        f"- Average score: {evaluation['score']}",
+        f"- Summary: {evaluation['summary']}",
+    ]
+
+    best_run = evaluation.get("best_run")
+    if best_run is not None:
+        lines.append(
+            f"- Best run: {format_config_label(best_run['config'])} | score={best_run['score']} | returncode={best_run['returncode']}"
+        )
+
+    if evaluation.get("highlights"):
+        lines.append("- Run highlights:")
+        for item in evaluation["highlights"]:
+            lines.append(
+                f"  • {item['config_label']} | {item['status']} | score={item['score']} | duration={item['duration_s']}s"
+            )
+            lines.append(f"    preview: {item['snippet']}")
+
+    return "\n".join(lines)
 
 
 def save_log(data):
@@ -92,6 +252,7 @@ def main():
     }
 
     log_file = save_log(log)
+    print(format_evaluation_report(evaluation))
     print(f"Saved log: {log_file}")
 
     notify(evaluation["summary"])

--- a/rain_lab.py
+++ b/rain_lab.py
@@ -9,6 +9,7 @@ Usage examples:
   python rain_lab.py           # Interactive wizard (recommended!)
   python rain_lab.py --mode first-run
   python rain_lab.py --mode chat --topic "Guarino paper"
+  python rain_lab.py --mode chat --topic "Guarino paper" --temp 0.85 --max-tokens 320
   python rain_lab.py --mode rlm --topic "Guarino paper"
   python rain_lab.py --mode validate
   python rain_lab.py --mode models
@@ -208,6 +209,18 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         help="Chat mode only: LM request timeout in seconds (default: 180; maps to --timeout)",
     )
     parser.add_argument(
+        "--temp",
+        type=float,
+        default=float(os.environ.get("RAIN_CHAT_TEMP", "0.7")),
+        help="Chat/Godot mode only: generation temperature (default: 0.7; set higher for more exploratory outputs)",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=int(os.environ.get("RAIN_CHAT_MAX_TOKENS", "320")),
+        help="Chat/Godot mode only: response token budget per turn (default: 320)",
+    )
+    parser.add_argument(
         "--recursive-depth",
         type=int,
         default=None,
@@ -405,6 +418,10 @@ def build_command(args: argparse.Namespace, passthrough: list[str], repo_root: P
             cmd.extend(["--max-turns", str(args.turns)])
         if args.timeout is not None:
             cmd.extend(["--timeout", str(args.timeout)])
+        if args.temp is not None:
+            cmd.extend(["--temp", str(args.temp)])
+        if args.max_tokens is not None:
+            cmd.extend(["--max-tokens", str(args.max_tokens)])
         if args.no_recursive_intellect or args.recursive_depth is None:
             cmd.append("--no-recursive-intellect")
         elif args.recursive_depth is not None:

--- a/rain_lab_meeting_chat_version.py
+++ b/rain_lab_meeting_chat_version.py
@@ -3150,6 +3150,7 @@ Examples:
   python rain_lab_v31_production.py --library ./my_papers --topic "field theory"
 
   python rain_lab_v31_production.py --temp 0.3 --topic "entanglement"
+  python rain_lab_v31_production.py --temp 0.85 --max-tokens 320 --topic "entanglement"
 
         """,
     )
@@ -3169,7 +3170,12 @@ Examples:
         help="LM Studio OpenAI-compatible base URL",
     )
 
-    parser.add_argument("--temp", type=float, default=0.4, help="LLM temperature (0.0-1.0, default: 0.4)")
+    parser.add_argument(
+        "--temp",
+        type=float,
+        default=float(os.environ.get("RAIN_CHAT_TEMP", "0.7")),
+        help="LLM temperature (0.0-1.0, default: 0.7; raise for more exploratory outputs)",
+    )
 
     parser.add_argument(
         "--recursive-depth",
@@ -3194,7 +3200,12 @@ Examples:
 
     parser.add_argument("--max-turns", type=int, default=25, help="Maximum conversation turns (default: 25)")
 
-    parser.add_argument("--max-tokens", type=int, default=200, help="Max tokens per response (default: 200)")
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=int(os.environ.get("RAIN_CHAT_MAX_TOKENS", "320")),
+        help="Max tokens per response (default: 320)",
+    )
 
     parser.add_argument(
         "--timeout",

--- a/tests/test_lab_orchestrator.py
+++ b/tests/test_lab_orchestrator.py
@@ -1,0 +1,89 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lab"))
+
+import orchestrator
+
+
+def test_preview_text_uses_non_empty_lines():
+    text = "\nfirst line\n\nsecond line\nthird line\n"
+    assert orchestrator.preview_text(text) == "first line | second line | third line"
+
+
+def test_run_experiments_reports_missing_runner(monkeypatch):
+    monkeypatch.delenv("LAB_EXPERIMENT_CMD", raising=False)
+    monkeypatch.setattr(orchestrator, "ROOT", Path("/tmp/zeroclaw-lab-test"))
+
+    result = orchestrator.run_experiments({"prompt_variant": "v1"})
+
+    assert result["returncode"] == 127
+    assert result["command"] is None
+    assert "LAB_EXPERIMENT_CMD" in result["stderr"]
+    assert result["stderr_preview"] != "(no output)"
+
+
+def test_evaluate_results_summarizes_successful_runs():
+    outputs = [
+        {
+            "config": {"prompt_variant": "v1"},
+            "returncode": 0,
+            "stdout": "alpha insight\nbeta detail\n",
+            "stderr": "",
+            "duration_s": 0.25,
+            "score": 120,
+            "stdout_preview": "alpha insight | beta detail",
+            "stderr_preview": "(no output)",
+        },
+        {
+            "config": {"prompt_variant": "v2"},
+            "returncode": 0,
+            "stdout": "gamma result",
+            "stderr": "",
+            "duration_s": 0.5,
+            "score": 140,
+            "stdout_preview": "gamma result",
+            "stderr_preview": "(no output)",
+        },
+    ]
+
+    evaluation = orchestrator.evaluate_results(outputs)
+
+    assert evaluation["success_count"] == 2
+    assert evaluation["failure_count"] == 0
+    assert evaluation["best_run"]["config"] == {"prompt_variant": "v2"}
+    assert "2/2 experiment runs succeeded" in evaluation["summary"]
+    assert evaluation["highlights"][0]["config_label"] == "prompt_variant=v2"
+
+
+def test_format_evaluation_report_includes_highlights():
+    evaluation = {
+        "total_runs": 1,
+        "success_count": 0,
+        "failure_count": 1,
+        "score": -150,
+        "summary": "1 experiment runs failed.",
+        "best_run": {
+            "config": {"prompt_variant": "v1"},
+            "score": -150,
+            "returncode": 1,
+            "stdout_preview": "(no output)",
+            "stderr_preview": "runner failed",
+        },
+        "highlights": [
+            {
+                "config": {"prompt_variant": "v1"},
+                "config_label": "prompt_variant=v1",
+                "status": "failed (1)",
+                "score": -150,
+                "duration_s": 0.1,
+                "snippet": "runner failed",
+            }
+        ],
+    }
+
+    report = orchestrator.format_evaluation_report(evaluation)
+
+    assert "Experiment evaluation:" in report
+    assert "prompt_variant=v1 | failed (1)" in report
+    assert "preview: runner failed" in report


### PR DESCRIPTION
### Motivation

- Provide a more robust experiment orchestration workflow that can locate a runner, score runs, and produce human-friendly summaries for easier triage. 
- Make chat/godot modes configurable for more exploratory generation by exposing temperature and token budget flags with environment defaults. 
- Improve observability and test coverage for orchestration behaviours. 

### Description

- Implemented experiment runner resolution via `resolve_experiment_command()` that honors `LAB_EXPERIMENT_CMD` or falls back to `run_experiments.py` if present. 
- Added utilities `preview_text()`, `format_config_label()` and `score_run()` and expanded `run_experiments()` to return structured output including `command`, `duration_s`, `score`, and previews. 
- Reworked `evaluate_results()` to rank runs, compute aggregate metrics (`total_runs`, `success_count`, `failure_count`, averages, totals), produce `highlights` and a `best_run` entry, and return a richer evaluation dict. 
- Added `format_evaluation_report()` and print it from `main()` so evaluations are human-readable at runtime. 
- Added CLI flags `--temp` and `--max-tokens` to `rain_lab.py` and wired them through to chat/godot subcommands, and updated `rain_lab_meeting_chat_version.py` to honor `RAIN_CHAT_TEMP` and `RAIN_CHAT_MAX_TOKENS` environment variables and new defaults. 
- Updated command reference docs in English, French and Vietnamese to show example usage of the `--temp` and `--max-tokens` options. 
- Added unit tests in `tests/test_lab_orchestrator.py` to cover `preview_text`, missing runner handling, evaluation aggregation, and report formatting. 

### Testing

- Ran `pytest tests/test_lab_orchestrator.py` and the new unit tests passed. 
- Ran `pytest -q` across the test suite and all tests passed. 
- Basic manual smoke runs of the orchestrator were performed to verify formatted reporting output and log file creation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9fff33de08324b95d05a4ce84a263)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
