### PR TITLE
Use `ubuntu-latest` runner and broaden push triggers in GitHub workflows

### DIFF
--- a/.github/workflows/ci-build-fast.yml
+++ b/.github/workflows/ci-build-fast.yml
@@ -5,7 +5,8 @@ name: CI Build (Fast)
 
 on:
     push:
-        branches: [dev, main]
+        branches:
+            - '**'
     pull_request:
         branches: [dev, main]
 
@@ -22,7 +23,7 @@ env:
 jobs:
     changes:
         name: Detect Change Scope
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         outputs:
             rust_changed: ${{ steps.scope.outputs.rust_changed }}
             docs_only: ${{ steps.scope.outputs.docs_only }}
@@ -43,7 +44,7 @@ jobs:
         name: Build (Fast)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.workflow_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -2,7 +2,8 @@ name: CI Run
 
 on:
     push:
-        branches: [dev, main]
+        branches:
+            - '**'
     pull_request:
         branches: [dev, main]
 
@@ -19,7 +20,7 @@ env:
 jobs:
     changes:
         name: Detect Change Scope
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         outputs:
             docs_only: ${{ steps.scope.outputs.docs_only }}
             docs_changed: ${{ steps.scope.outputs.docs_changed }}
@@ -44,7 +45,7 @@ jobs:
         name: Lint Gate (Format + Clippy + Strict Delta)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -66,7 +67,7 @@ jobs:
         name: Test
         needs: [changes, lint]
         if: needs.changes.outputs.rust_changed == 'true' && needs.lint.result == 'success'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -81,7 +82,7 @@ jobs:
         name: Build (Smoke)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 20
 
         steps:
@@ -99,7 +100,7 @@ jobs:
         name: Docs-Only Fast Path
         needs: [changes]
         if: needs.changes.outputs.docs_only == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         steps:
             - name: Skip heavy jobs for docs-only change
               run: echo "Docs-only change detected. Rust lint/test/build skipped."
@@ -108,7 +109,7 @@ jobs:
         name: Non-Rust Fast Path
         needs: [changes]
         if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.rust_changed != 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         steps:
             - name: Skip Rust jobs for non-Rust change scope
               run: echo "No Rust-impacting files changed. Rust lint/test/build skipped."
@@ -117,7 +118,7 @@ jobs:
         name: Docs Quality
         needs: [changes]
         if: needs.changes.outputs.docs_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -172,7 +173,7 @@ jobs:
         name: Lint Feedback
         if: github.event_name == 'pull_request'
         needs: [changes, lint, docs-quality]
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         permissions:
             contents: read
             pull-requests: write
@@ -198,7 +199,7 @@ jobs:
         name: Workflow Owner Approval
         needs: [changes]
         if: github.event_name == 'pull_request' && needs.changes.outputs.workflow_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         permissions:
             contents: read
             pull-requests: read
@@ -219,7 +220,7 @@ jobs:
         name: License File Owner Guard
         needs: [changes]
         if: github.event_name == 'pull_request'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         permissions:
             contents: read
             pull-requests: read
@@ -237,7 +238,7 @@ jobs:
         name: CI Required Gate
         if: always()
         needs: [changes, lint, test, build, docs-only, non-rust, docs-quality, lint-feedback, workflow-owner-approval, license-file-owner-guard]
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         steps:
             - name: Enforce required status
               shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ permissions:
   contents: read
 on:
   push:
-    branches: [dev, main]
+    branches:
+      - '**'
   pull_request:
     branches: [dev, main]
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -2,7 +2,8 @@ name: Test E2E
 
 on:
     push:
-        branches: [dev, main]
+        branches:
+            - '**'
     workflow_dispatch:
 
 concurrency:
@@ -18,7 +19,7 @@ env:
 jobs:
     integration-tests:
         name: Integration / E2E Tests
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
     no-tabs:
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
             - name: Checkout
@@ -54,7 +54,7 @@ jobs:
                   PY
 
     actionlint:
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
             - name: Checkout


### PR DESCRIPTION
### Motivation
- Remove dependency on a custom `blacksmith-2vcpu-ubuntu-2404` runner in workflow configs and standardize on the maintained `ubuntu-latest` runner.
- Broaden the `push` trigger to run CI on pushes to any branch by changing the branch filter to `- '**'` so workflow runs are not limited to `dev` and `main`.

### Description
- Replaced `runs-on: blacksmith-2vcpu-ubuntu-2404` with `runs-on: ubuntu-latest` across multiple workflow files, including `ci-build-fast.yml`, `ci-run.yml`, `test-e2e.yml`, `workflow-sanity.yml`, and others.
- Changed `push.branches` from `branches: [dev, main]` to `branches: - '**'` in `ci-build-fast.yml`, `ci-run.yml`, `ci.yml`, and `test-e2e.yml` to broaden push events.
- Preserved existing job steps, timeouts, concurrency groups, and tooling pins (Rust toolchain, cache actions, lint/test/build steps) so runtime behavior of jobs remains unchanged.

### Testing
- No automated tests were executed as part of this change because the updates are limited to CI workflow configuration files; the updated workflows will be exercised by GitHub Actions on the next push or pull request.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb65f186ec83248914606d32b66348)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
