### PR TITLE
CI: switch workflows to ubuntu-latest and fix detect_change_scope output handling

### DIFF
--- a/.github/workflows/ci-build-fast.yml
+++ b/.github/workflows/ci-build-fast.yml
@@ -5,7 +5,6 @@ name: CI Build (Fast)
 
 on:
     push:
-        branches: [dev, main]
     pull_request:
         branches: [dev, main]
 
@@ -22,7 +21,7 @@ env:
 jobs:
     changes:
         name: Detect Change Scope
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         outputs:
             rust_changed: ${{ steps.scope.outputs.rust_changed }}
             docs_only: ${{ steps.scope.outputs.docs_only }}
@@ -43,7 +42,7 @@ jobs:
         name: Build (Fast)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.workflow_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -2,7 +2,6 @@ name: CI Run
 
 on:
     push:
-        branches: [dev, main]
     pull_request:
         branches: [dev, main]
 
@@ -19,7 +18,7 @@ env:
 jobs:
     changes:
         name: Detect Change Scope
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         outputs:
             docs_only: ${{ steps.scope.outputs.docs_only }}
             docs_changed: ${{ steps.scope.outputs.docs_changed }}
@@ -44,7 +43,7 @@ jobs:
         name: Lint Gate (Format + Clippy + Strict Delta)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -66,7 +65,7 @@ jobs:
         name: Test
         needs: [changes, lint]
         if: needs.changes.outputs.rust_changed == 'true' && needs.lint.result == 'success'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -81,7 +80,7 @@ jobs:
         name: Build (Smoke)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 20
 
         steps:
@@ -99,7 +98,7 @@ jobs:
         name: Docs-Only Fast Path
         needs: [changes]
         if: needs.changes.outputs.docs_only == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         steps:
             - name: Skip heavy jobs for docs-only change
               run: echo "Docs-only change detected. Rust lint/test/build skipped."
@@ -108,7 +107,7 @@ jobs:
         name: Non-Rust Fast Path
         needs: [changes]
         if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.rust_changed != 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         steps:
             - name: Skip Rust jobs for non-Rust change scope
               run: echo "No Rust-impacting files changed. Rust lint/test/build skipped."
@@ -117,7 +116,7 @@ jobs:
         name: Docs Quality
         needs: [changes]
         if: needs.changes.outputs.docs_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -172,7 +171,7 @@ jobs:
         name: Lint Feedback
         if: github.event_name == 'pull_request'
         needs: [changes, lint, docs-quality]
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         permissions:
             contents: read
             pull-requests: write
@@ -198,7 +197,7 @@ jobs:
         name: Workflow Owner Approval
         needs: [changes]
         if: github.event_name == 'pull_request' && needs.changes.outputs.workflow_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         permissions:
             contents: read
             pull-requests: read
@@ -219,7 +218,7 @@ jobs:
         name: License File Owner Guard
         needs: [changes]
         if: github.event_name == 'pull_request'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         permissions:
             contents: read
             pull-requests: read
@@ -237,7 +236,7 @@ jobs:
         name: CI Required Gate
         if: always()
         needs: [changes, lint, test, build, docs-only, non-rust, docs-quality, lint-feedback, workflow-owner-approval, license-file-owner-guard]
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         steps:
             - name: Enforce required status
               shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ permissions:
   contents: read
 on:
   push:
-    branches: [dev, main]
   pull_request:
     branches: [dev, main]
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -2,7 +2,6 @@ name: Test E2E
 
 on:
     push:
-        branches: [dev, main]
     workflow_dispatch:
 
 concurrency:
@@ -18,7 +17,7 @@ env:
 jobs:
     integration-tests:
         name: Integration / E2E Tests
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
     no-tabs:
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
             - name: Checkout
@@ -54,7 +54,7 @@ jobs:
                   PY
 
     actionlint:
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
             - name: Checkout

--- a/scripts/ci/detect_change_scope.sh
+++ b/scripts/ci/detect_change_scope.sh
@@ -13,10 +13,11 @@ write_empty_docs_files() {
   {
     echo "docs_files<<EOF"
     echo "EOF"
-  } >> "$GITHUB_OUTPUT"
+  } >> "$OUTPUT_FILE"
 }
 
-BASE="$BASE_SHA"
+OUTPUT_FILE="${GITHUB_OUTPUT:-/tmp/zeroclaw_detect_change_scope.out}"
+BASE="${BASE_SHA:-}"
 
 if [ -z "$BASE" ] || ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
   {
@@ -25,7 +26,7 @@ if [ -z "$BASE" ] || ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
     echo "rust_changed=true"
     echo "workflow_changed=false"
     echo "base_sha="
-  } >> "$GITHUB_OUTPUT"
+  } >> "$OUTPUT_FILE"
   write_empty_docs_files
   exit 0
 fi
@@ -48,7 +49,7 @@ if [ -z "$CHANGED" ]; then
     echo "rust_changed=false"
     echo "workflow_changed=false"
     echo "base_sha=$DIFF_BASE"
-  } >> "$GITHUB_OUTPUT"
+  } >> "$OUTPUT_FILE"
   write_empty_docs_files
   exit 0
 fi
@@ -102,4 +103,4 @@ done <<< "$CHANGED"
   echo "docs_files<<EOF"
   printf '%s\n' "${docs_files[@]}"
   echo "EOF"
-} >> "$GITHUB_OUTPUT"
+} >> "$OUTPUT_FILE"


### PR DESCRIPTION
### Motivation

- Standardize CI to GitHub-hosted runners by replacing a custom runner label and ensure workflow triggers and change-detection behave correctly across environments.

### Description

- Replaced `runs-on: blacksmith-2vcpu-ubuntu-2404` with `runs-on: ubuntu-latest` across multiple workflow files including `ci-build-fast.yml`, `ci-run.yml`, `test-e2e.yml`, `workflow-sanity.yml`, and others.
- Removed explicit `push: branches: [dev, main]` branch filters from several workflows so push triggers are not restricted to `dev`/`main` only.
- Fixed `scripts/ci/detect_change_scope.sh` to use an `OUTPUT_FILE` derived from `GITHUB_OUTPUT` (with a sane default) and to safely initialize `BASE` from `BASE_SHA`, and updated all writes to use that output file.

### Testing

- No automated unit tests were added or modified for this change.
- These edits are limited to CI workflow configuration and the CI helper script, so no repository test suites were executed as part of this patch; CI should validate the changes when workflows run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb65f186ec83248914606d32b66348)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
