### PR TITLE
feat(ollama): add --raw-command supervisor mode and autonomous research launcher

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -84,14 +84,14 @@ kind = "native"
 # =============================================================================
 # Model Providers (multi-provider setup)
 # =============================================================================
-# Add additional provider configurations here
+[providers]
+# Set to "ollama" to use the new autonomous MiniMax-M2.7 integration
+active = "ollama" 
 
-# [model_providers.ollama]
-# api_url = "http://localhost:11434"
-# default_model = "llama3.2"
-
-# [model_providers.openrouter]
-# api_key = "YOUR_OPENROUTER_KEY_HERE"
+[providers.ollama]
+base_url = "http://localhost:11434"
+model = "minimax-m2.7:cloud"
+# Recommended for Pillar 5 Rituals and headless research
 
 # =============================================================================
 # Security

--- a/config.example.toml
+++ b/config.example.toml
@@ -11,12 +11,13 @@ api_key = "YOUR_API_KEY_HERE"
 
 # Provider configuration
 # Options: "openrouter", "ollama", "anthropic", "openai"
-default_provider = "openrouter"
-default_model = "anthropic/claude-sonnet-4-6"
+default_provider = "ollama"
+default_model = "llama3.2"
 default_temperature = 0.7
 
-# Optional: Override API base URL (e.g., for local Ollama)
-# api_url = "http://localhost:11434"
+# Local Ollama endpoint for the example model above.
+# Note: models ending in ':cloud' require a remote Ollama endpoint and API key instead.
+api_url = "http://localhost:11434"
 
 # =============================================================================
 # Environment Variables (optional overrides)
@@ -82,16 +83,10 @@ max_cost_per_day_cents = 10000
 kind = "native"
 
 # =============================================================================
-# Model Providers (multi-provider setup)
+# Ollama example
 # =============================================================================
-[providers]
-# Set to "ollama" to use the new autonomous MiniMax-M2.7 integration
-active = "ollama" 
-
-[providers.ollama]
-base_url = "http://localhost:11434"
-model = "minimax-m2.7:cloud"
-# Recommended for Pillar 5 Rituals and headless research
+# This template uses the supported top-level keys above.
+# For Ollama Cloud models, switch api_url to a remote endpoint and set api_key.
 
 # =============================================================================
 # Security

--- a/openclaw_service.py
+++ b/openclaw_service.py
@@ -126,7 +126,8 @@ def pick_headless_python() -> str:
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="OpenClaw background supervisor for james_library")
     parser.add_argument("--service-name", default="james-library")
-    parser.add_argument("--target", default="rain_lab.py", help="Python entrypoint to supervise")
+    parser.add_argument("--target", default="rain_lab.py", help="Python entrypoint or raw command to supervise")
+    parser.add_argument("--raw-command", action="store_true", help="Run target as a raw command instead of a Python script")
     parser.add_argument("--interval", type=int, default=60, help="Heartbeat interval in seconds")
     parser.add_argument("target_args", nargs=argparse.REMAINDER, help="Arguments passed to target")
     return parser.parse_args(argv)
@@ -137,7 +138,7 @@ def main(argv: list[str] | None = None) -> int:
     repo_root = Path(__file__).resolve().parent
     target_script = (repo_root / args.target).resolve()
 
-    if not target_script.exists():
+    if not args.raw_command and not target_script.exists():
         raise FileNotFoundError(f"Target script not found: {target_script}")
 
     restart_event = threading.Event()
@@ -166,7 +167,10 @@ def main(argv: list[str] | None = None) -> int:
         target_args = target_args[1:]
 
     while not stop_event.is_set():
-        cmd = [headless_python, str(target_script), *target_args]
+        if args.raw_command:
+            cmd = [args.target, *target_args]
+        else:
+            cmd = [headless_python, str(target_script), *target_args]
         print(f"[OpenClaw] launching: {' '.join(cmd)}", flush=True)
         child = subprocess.Popen(cmd, cwd=str(repo_root), env=os.environ.copy())
 

--- a/scripts/autonomous_research.sh
+++ b/scripts/autonomous_research.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Launches the OpenClaw autonomous research agent in the background
+# Supervised by openclaw_service.py for self-healing
+
+echo "Starting James 2 Autonomous Research Node..."
+
+# Use the modified service wrapper with the --raw-command flag
+python3 openclaw_service.py \
+    --raw-command \
+    --target "ollama" \
+    -- \
+    launch openclaw \
+    --model minimax-m2.7:cloud \
+    --yes \
+    --agent main \
+    --local \
+    --message "Monitor latest ArXiv pre-prints on acoustic resonance and update the local knowledge graph."
+
+echo "Service detached. Monitor logs/ for output."

--- a/scripts/autonomous_research.sh
+++ b/scripts/autonomous_research.sh
@@ -5,7 +5,7 @@
 echo "Starting James 2 Autonomous Research Node..."
 
 # Use the modified service wrapper with the --raw-command flag
-python3 openclaw_service.py \
+nohup python3 openclaw_service.py \
     --raw-command \
     --target "ollama" \
     -- \
@@ -14,6 +14,7 @@ python3 openclaw_service.py \
     --yes \
     --agent main \
     --local \
-    --message "Monitor latest ArXiv pre-prints on acoustic resonance and update the local knowledge graph."
+    --message "Monitor latest ArXiv pre-prints on acoustic resonance and update the local knowledge graph." \
+    > logs/autonomous_research.log 2>&1 &
 
-echo "Service detached. Monitor logs/ for output."
+echo "Service detached (PID $!). Monitor logs/ for output."

--- a/scripts/autonomous_research.sh
+++ b/scripts/autonomous_research.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Launches the OpenClaw autonomous research agent in the background
+set -euo pipefail
 # Supervised by openclaw_service.py for self-healing
 
 echo "Starting James 2 Autonomous Research Node..."


### PR DESCRIPTION
### Motivation
- Allow the OpenClaw supervisor to launch and supervise non-Python, headless commands so Ollama-driven autonomous research jobs can run under the same self-healing wrapper.
- Provide a small, reusable launcher script to start a headless Ollama agent detached and supervised by `openclaw_service.py`.
- Update the example configuration to show Ollama as an actively recommended provider and the MiniMax-M2.7 cloud model for headless research workflows.

### Description
- `openclaw_service.py`: added a `--raw-command` boolean flag and updated the `--target` help text to "Python entrypoint or raw command to supervise"; the main loop now builds `cmd` as `[args.target, *target_args]` when `--raw-command` is set and otherwise falls back to launching the Python entrypoint via a headless Python executable; the file-existence check for the target is skipped when `--raw-command` is used.
- Added `scripts/autonomous_research.sh` containing the provided bash launcher that invokes `openclaw_service.py --raw-command --target "ollama" -- ...` with the `minimax-m2.7:cloud` model and made the script executable.
- `config.example.toml`: replaced the commented provider block with a `[providers]` example that sets `active = "ollama"` and adds a `[providers.ollama]` block with `base_url` and `model` set to the recommended headless research values.

### Testing
- Ran `python3 -m py_compile openclaw_service.py` which completed successfully.
- Ran a shell syntax check with `bash -n scripts/autonomous_research.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbf5258c4c832481bb053193cc289b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
