### PR TITLE
docs(release): add James v2.5.0 release notes and artwork

### DIFF
--- a/RELEASE_NOTES_JAMES_2_5_0.md
+++ b/RELEASE_NOTES_JAMES_2_5_0.md
@@ -1,0 +1,60 @@
+# James v2.5.0: The Autonomous Node
+
+![James 2.5 // R.A.I.N. Lab release art](assets/james_2_5_release.svg)
+
+**Release:** James v2.5.0 — The Autonomous Node  
+**Date:** 2026-03-19
+
+## Highlights
+
+James v2.5.0 marks the transition of R.A.I.N. Lab from an interactive research assistant into a persistent, self-healing, background scientific operating system. This release officially unlocks **Phase 3** of the product roadmap by bringing autonomous scheduled research jobs online, connecting them to grounded local workflows, and closing the loop between execution, supervision, and memory.
+
+The result is a more rigorous mode of operation: James can now continue monitoring pre-prints, synthesizing findings, and preserving successful research procedures even when no terminal UI is open. In practical terms, advanced autonomous scientific reasoning now belongs where it should — on local hardware, under user control, and built on open-source infrastructure.
+
+## New Features
+
+### Autonomous Research Service
+- Added `scripts/autonomous_research.sh` to launch the multi-agent swarm as a detached background job.
+- Fulfills **Pillar 10 — Autonomous Research Service** from the roadmap by enabling continuous research execution outside the terminal UI.
+- Establishes a practical always-on workflow for monitoring research streams such as ArXiv and updating local knowledge artifacts over time.
+
+### Headless Ollama + MiniMax Background Execution
+- Added full support for Ollama's non-interactive `--yes` flow in the new autonomous launch path.
+- Officially recommends `minimax-m2.7:cloud` for unattended background execution because of its tuning for self-improvement loops and web-scale synthesis tasks.
+- Makes autonomous research runs reproducible and scriptable without interactive confirmation prompts interrupting overnight jobs.
+
+### Self-Healing Heartbeat Monitor
+- Upgraded `openclaw_service.py` with a new `--raw-command` flag so the supervisor can directly monitor raw headless Ollama CLI processes.
+- Extends the heartbeat monitor to detect crash and stall signatures from long-running log streams and automatically restart the swarm when failures are detected.
+- Improves resilience for extended simulations, pre-print monitoring loops, and unattended synthesis sessions.
+
+### Ritual Workflows
+- Advances **Pillar 5 — Ritual Workflows** by enabling James to preserve successful research logic as reusable operating patterns.
+- Connects autonomous execution with the Action-to-Text Episodic Memory Graph so useful workflows can be ingested and retained as repeatable **Rituals**.
+- Pushes the system beyond one-off conversations toward self-reinforcing scientific process memory.
+
+## Improvements
+
+### Architecture
+- Unifies background orchestration, supervision, and model execution into a coherent autonomous node workflow.
+- Strengthens the local-first operating model by shifting serious autonomous reasoning toward supervised background services rather than fragile foreground sessions.
+- Sharpens the R.A.I.N. Lab product identity around persistent scientific operations instead of purely interactive assistance.
+
+### Reliability
+- Adds a clearer self-healing loop for overnight or long-horizon runs where local reasoning jobs may crash, hang, or degrade over time.
+- Reduces operator burden by moving failure recovery into the service layer instead of requiring manual intervention.
+
+### Research Operations
+- Makes 24/7 pre-print and synthesis workflows a first-class part of the system.
+- Enables the swarm to accumulate usable research state in the background and convert successful strategies into future reusable cognition patterns.
+
+## Stats
+
+- **Phase 3 unlocked** — the roadmap now advances from trust-and-security foundations into productized autonomous research execution.
+- **2 major roadmap pillars advanced** — Pillar 10 (Autonomous Research Service) and Pillar 5 (Ritual Workflows).
+- **1 persistent node workflow added** — a detached, supervised, self-healing background research service.
+- **24/7 operating model enabled** — James can now monitor, synthesize, and recover without a live terminal session.
+
+---
+
+Built for local-first autonomous science. Open-source, user-controlled, and designed to keep advanced reasoning close to the hardware.

--- a/assets/james_2_5_release.svg
+++ b/assets/james_2_5_release.svg
@@ -1,0 +1,56 @@
+<svg width="1600" height="1600" viewBox="0 0 1600 1600" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1600" y2="1600" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FAF6E8"/>
+      <stop offset="1" stop-color="#F3E8C5"/>
+    </linearGradient>
+    <linearGradient id="pool" x1="1020" y1="1240" x2="1350" y2="1450" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#97F6FF"/>
+      <stop offset="1" stop-color="#68C9E8"/>
+    </linearGradient>
+    <filter id="shadow" x="0" y="0" width="200%" height="200%">
+      <feDropShadow dx="0" dy="10" stdDeviation="16" flood-color="#B7A566" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+
+  <rect width="1600" height="1600" rx="32" fill="url(#bg)"/>
+  <text x="90" y="160" font-family="Arial, Helvetica, sans-serif" font-size="112" font-weight="700" fill="#090909">James 2.5 // R.A.I.N. Lab</text>
+  <text x="104" y="235" font-family="Arial, Helvetica, sans-serif" font-size="42" font-weight="700" fill="#090909">from Vers3Dynamics</text>
+
+  <g filter="url(#shadow)">
+    <rect x="95" y="330" width="1410" height="1120" rx="20" fill="#FFF2CC"/>
+    <polygon points="95,330 760,330 760,760 95,980" fill="#2B5FD3"/>
+    <polygon points="350,330 1390,330 1180,520 160,940" fill="#FFE066"/>
+    <rect x="810" y="500" width="320" height="420" rx="10" fill="#F5A05F"/>
+    <rect x="1085" y="760" width="360" height="430" rx="10" fill="#D6F4D2"/>
+    <polygon points="95,930 720,930 610,1450 95,1180" fill="#CFF3DB"/>
+    <polygon points="1020,1120 1460,1120 1460,1450 840,1450" fill="#F6B48B"/>
+    <rect x="1020" y="1240" width="330" height="210" rx="12" fill="url(#pool)"/>
+
+    <g fill="#FFE066">
+      <polygon points="1200,350 1450,350 1350,420 1200,420"/>
+      <polygon points="1210,420 1450,420 1390,490 1210,490"/>
+      <polygon points="1220,490 1450,490 1410,560 1220,560"/>
+      <polygon points="1230,560 1450,560 1420,630 1230,630"/>
+      <polygon points="1240,630 1450,630 1430,700 1240,700"/>
+      <polygon points="1250,700 1450,700 1440,770 1250,770"/>
+      <polygon points="1260,770 1450,770 1450,840 1260,840"/>
+    </g>
+
+    <g>
+      <ellipse cx="760" cy="680" rx="150" ry="150" fill="#A61C2E"/>
+      <ellipse cx="810" cy="930" rx="200" ry="230" fill="#B71E34"/>
+      <path d="M610 850C470 810 380 820 310 760" stroke="#A61C2E" stroke-width="92" stroke-linecap="round"/>
+      <path d="M640 930C520 970 420 1040 360 1180" stroke="#A61C2E" stroke-width="84" stroke-linecap="round"/>
+      <path d="M740 1040C690 1160 640 1260 540 1360" stroke="#A61C2E" stroke-width="70" stroke-linecap="round"/>
+      <path d="M900 980C1050 950 1140 980 1240 1110" stroke="#A61C2E" stroke-width="82" stroke-linecap="round"/>
+      <path d="M980 860C1090 760 1140 680 1080 560" stroke="#A61C2E" stroke-width="78" stroke-linecap="round"/>
+      <path d="M840 780C780 720 710 720 660 780" stroke="#7D1322" stroke-width="30" stroke-linecap="round"/>
+      <ellipse cx="810" cy="760" rx="36" ry="28" fill="#FFF9EA"/>
+      <ellipse cx="823" cy="764" rx="12" ry="12" fill="#090909"/>
+    </g>
+  </g>
+
+  <text x="1545" y="1380" transform="rotate(-90 1545 1380)" font-family="Arial, Helvetica, sans-serif" font-size="34" font-weight="700" fill="#090909">Rust • Python • Local-first • Open-source</text>
+  <text x="100" y="1525" font-family="Arial, Helvetica, sans-serif" font-size="42" font-weight="700" fill="#222222">The Autonomous Node</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Announce the Phase 3 transition of R.A.I.N. Lab to a persistent, self-healing background scientific OS and preserve the release in-repo with the same Highlights/New Features/Improvements/Stats structure used in prior James releases. 
- Ship an embeddable release image so the notes render with artwork on GitHub and in local markdown viewers.

### Description
- Add `RELEASE_NOTES_JAMES_2_5_0.md`, a GitHub-style release announcement titled “James v2.5.0: The Autonomous Node” that documents the Autonomous Research Service, headless Ollama + `minimax-m2.7:cloud` background execution, the `--raw-command` self-healing heartbeat in `openclaw_service.py`, and Ritual workflow integration with episodic memory. 
- Add `assets/james_2_5_release.svg` and embed it at the top of the release notes so the release renders with project-native artwork.

### Testing
- Ran `cargo fmt --all -- --check`, which completed successfully. 
- Ran the docs gate `bash ./scripts/ci/docs_quality_gate.sh`, which completed (reported no docs files to check in this environment). 
- Attempted `npx --yes markdownlint-cli2 RELEASE_NOTES_JAMES_2_5_0.md`, which failed in this environment due to an external npm registry `403 Forbidden`. 
- `cargo clippy --all-targets -- -D warnings` and `cargo test` were started but the workspace build was still compiling dependencies in this environment, so those checks did not finish before handoff.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc00d35af08324866b8a73befbbf4e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
