### PR TITLE
feat(p2p): restore libp2p module and startup wiring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,9 @@ futures-util = { version = "0.3", default-features = false, features = ["sink"] 
 nostr-sdk = { version = "0.44", default-features = false, features = ["nip04", "nip59"], optional = true }
 regex = "1.10"
 hostname = "0.4.2"
+
+# libp2p — P2P networking with gossipsub + Kademlia DHT (optional, enable with --features p2p)
+libp2p = { version = "0.54", optional = true, default-features = false, features = ["gossipsub", "kad", "noise", "tcp", "yamux", "tokio", "macros", "identify"] }
 rustls = "0.23"
 rustls-pki-types = "1.14.0"
 tokio-rustls = "0.26.4"
@@ -244,6 +247,8 @@ rag-pdf = ["dep:pdf-extract"]
 whatsapp-web = ["dep:wa-rs", "dep:wa-rs-core", "dep:wa-rs-binary", "dep:wa-rs-proto", "dep:wa-rs-ureq-http", "dep:wa-rs-tokio-transport", "dep:serde-big-array", "dep:prost", "dep:qrcode"]
 # WASM plugin system (extism-based)
 plugins-wasm = ["dep:extism"]
+# p2p = libp2p-based gossipsub + Kademlia DHT for decentralized agent networking
+p2p = ["dep:libp2p"]
 
 [profile.release]
 opt-level = "z"      # Optimize for size

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -316,6 +316,10 @@ pub struct Config {
     #[serde(default)]
     pub nodes: NodesConfig,
 
+    /// P2P networking configuration: gossipsub + Kademlia DHT (`[p2p]`).
+    #[serde(default)]
+    pub p2p: P2pConfig,
+
     /// Multi-client workspace isolation configuration (`[workspace]`).
     #[serde(default)]
     pub workspace: WorkspaceConfig,
@@ -828,6 +832,76 @@ impl Default for NodesConfig {
             enabled: false,
             max_nodes: default_max_nodes(),
             auth_token: None,
+        }
+    }
+}
+
+// ── P2P networking (gossipsub + Kademlia DHT) ────────────────────
+
+fn default_p2p_listen_addr() -> String {
+    "/ip4/127.0.0.1/tcp/0".into()
+}
+
+fn default_p2p_max_message_size() -> usize {
+    1024
+}
+
+fn default_p2p_max_peers() -> usize {
+    50
+}
+
+/// P2P networking configuration for decentralized agent communication.
+///
+/// Uses libp2p gossipsub for pub/sub messaging and Kademlia DHT for
+/// peer discovery and distributed record storage.
+///
+/// Requires the `p2p` feature flag at compile time. At runtime, set
+/// `enabled = true` in `[p2p]` or `ZEROCLAW_P2P_ENABLE=1`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct P2pConfig {
+    /// Enable P2P networking. Default: `false`.
+    /// Can also be enabled via `ZEROCLAW_P2P_ENABLE=1` env var.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Multiaddr to listen on. Default: `"/ip4/127.0.0.1/tcp/0"` (random port, localhost only).
+    /// Override with `ZEROCLAW_P2P_LISTEN_ADDR` env var.
+    #[serde(default = "default_p2p_listen_addr")]
+    pub listen_addr: String,
+
+    /// Comma-separated list of bootstrap peer multiaddrs (must include `/p2p/<peer_id>`).
+    /// Override with `ZEROCLAW_P2P_BOOTSTRAP` env var.
+    #[serde(default)]
+    pub bootstrap_peers: Vec<String>,
+
+    /// Gossipsub topics to subscribe to. Default: `["zeroclaw/advisory"]`.
+    #[serde(default)]
+    pub topics: Vec<String>,
+
+    /// Maximum gossip message size in bytes. Default: `1024`.
+    #[serde(default = "default_p2p_max_message_size")]
+    pub max_message_size: usize,
+
+    /// Maximum number of connected peers. Default: `50`.
+    #[serde(default = "default_p2p_max_peers")]
+    pub max_peers: usize,
+
+    /// Node identifier broadcast to peers. Falls back to hostname if unset.
+    /// Override with `ZEROCLAW_NODE_ID` env var.
+    #[serde(default)]
+    pub node_id: Option<String>,
+}
+
+impl Default for P2pConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            listen_addr: default_p2p_listen_addr(),
+            bootstrap_peers: Vec::new(),
+            topics: Vec::new(),
+            max_message_size: default_p2p_max_message_size(),
+            max_peers: default_p2p_max_peers(),
+            node_id: None,
         }
     }
 }
@@ -5985,6 +6059,7 @@ impl Default for Config {
             tts: TtsConfig::default(),
             mcp: McpConfig::default(),
             nodes: NodesConfig::default(),
+            p2p: P2pConfig::default(),
             workspace: WorkspaceConfig::default(),
             notion: NotionConfig::default(),
             node_transport: NodeTransportConfig::default(),
@@ -8421,6 +8496,7 @@ default_temperature = 0.7
             tts: TtsConfig::default(),
             mcp: McpConfig::default(),
             nodes: NodesConfig::default(),
+            p2p: P2pConfig::default(),
             workspace: WorkspaceConfig::default(),
             notion: NotionConfig::default(),
             node_transport: NodeTransportConfig::default(),
@@ -8754,6 +8830,7 @@ tool_dispatcher = "xml"
             tts: TtsConfig::default(),
             mcp: McpConfig::default(),
             nodes: NodesConfig::default(),
+            p2p: P2pConfig::default(),
             workspace: WorkspaceConfig::default(),
             notion: NotionConfig::default(),
             node_transport: NodeTransportConfig::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub(crate) mod multimodal;
 pub mod nodes;
 pub mod observability;
 pub(crate) mod onboard;
+pub mod p2p;
 pub mod peripherals;
 pub mod providers;
 pub mod rag;

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,7 @@ mod migration;
 mod multimodal;
 mod observability;
 mod onboard;
+mod p2p;
 mod peripherals;
 #[cfg(feature = "plugins-wasm")]
 mod plugins;
@@ -943,6 +944,9 @@ async fn main() -> Result<()> {
             peripheral,
         } => {
             let final_temperature = temperature.unwrap_or(config.default_temperature);
+            p2p::ensure_runtime_started(&config.p2p)
+                .await
+                .context("failed to start p2p runtime for agent startup")?;
 
             Box::pin(agent::run(
                 config,
@@ -1063,6 +1067,9 @@ async fn main() -> Result<()> {
             } else {
                 info!("🧠 Starting ZeroClaw Daemon on {host}:{port}");
             }
+            p2p::ensure_runtime_started(&config.p2p)
+                .await
+                .context("failed to start p2p runtime for daemon startup")?;
             Box::pin(daemon::run(config, host, port)).await
         }
 

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,0 +1,316 @@
+use serde::Serialize;
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const DEFAULT_ADVISORY_TOPIC: &str = "zeroclaw/advisory";
+const DEFAULT_LISTEN_ADDR: &str = "/ip4/127.0.0.1/tcp/0";
+const MAX_ADVISORY_PAYLOAD: usize = 512;
+
+/// Serialized payload published to gossip topics.
+#[derive(Debug, Clone, Serialize)]
+pub struct AdvisoryExperimentResult {
+    pub ts: u64,
+    pub node: String,
+    pub topic: String,
+    pub advisory: bool,
+    pub body: String,
+}
+
+/// Summary of a connected peer.
+#[derive(Debug, Clone, Serialize)]
+pub struct PeerInfo {
+    pub peer_id: String,
+    pub addresses: Vec<String>,
+}
+
+/// Snapshot of the running P2P node status.
+#[derive(Debug, Clone, Serialize)]
+pub struct P2pStatus {
+    pub enabled: bool,
+    pub running: bool,
+    pub local_peer_id: Option<String>,
+    pub listen_addresses: Vec<String>,
+    pub connected_peers: usize,
+    pub subscribed_topics: Vec<String>,
+}
+
+/// Resolved P2P runtime configuration merging config file + env overrides.
+#[derive(Debug, Clone)]
+pub struct P2pRuntimeConfig {
+    pub listen_addr: String,
+    pub bootstrap_peers: Vec<String>,
+    pub topics: Vec<String>,
+    pub max_message_size: usize,
+    pub max_peers: usize,
+    pub node_id: String,
+}
+
+impl P2pRuntimeConfig {
+    /// Build from config schema, applying env-var overrides.
+    pub fn from_config(cfg: &crate::config::schema::P2pConfig) -> Self {
+        let listen_addr = std::env::var("ZEROCLAW_P2P_LISTEN_ADDR")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| {
+                if cfg.listen_addr.is_empty() {
+                    DEFAULT_LISTEN_ADDR.to_string()
+                } else {
+                    cfg.listen_addr.clone()
+                }
+            });
+
+        let bootstrap_peers = std::env::var("ZEROCLAW_P2P_BOOTSTRAP")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .map(|raw| {
+                raw.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
+            .unwrap_or_else(|| cfg.bootstrap_peers.clone());
+
+        let mut topics = cfg.topics.clone();
+        if topics.is_empty() {
+            topics.push(DEFAULT_ADVISORY_TOPIC.to_string());
+        }
+
+        let node_id = std::env::var("ZEROCLAW_NODE_ID")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .or_else(|| cfg.node_id.clone())
+            .unwrap_or_else(|| {
+                hostname::get().map_or_else(
+                    |_| "zeroclaw_node".to_string(),
+                    |h| h.to_string_lossy().into_owned(),
+                )
+            });
+
+        Self {
+            listen_addr,
+            bootstrap_peers,
+            topics,
+            max_message_size: cfg.max_message_size,
+            max_peers: cfg.max_peers,
+            node_id,
+        }
+    }
+}
+
+/// Check whether P2P is enabled (config or env).
+pub fn p2p_enabled(cfg: &crate::config::schema::P2pConfig) -> bool {
+    if cfg.enabled {
+        return true;
+    }
+    std::env::var("ZEROCLAW_P2P_ENABLE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+// ── libp2p runtime (only compiled with p2p feature) ────────────────
+
+#[cfg(feature = "p2p")]
+mod runtime;
+
+#[cfg(feature = "p2p")]
+pub use runtime::{
+    ensure_runtime_started, get_dht_record, get_status, publish_advisory_result, publish_to_topic,
+    put_dht_record,
+};
+
+// ── Stubs when p2p feature is disabled ─────────────────────────────
+
+#[cfg(not(feature = "p2p"))]
+#[allow(clippy::unused_async)]
+pub async fn ensure_runtime_started(_cfg: &crate::config::schema::P2pConfig) -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(feature = "p2p"))]
+#[allow(clippy::unused_async)]
+pub async fn publish_advisory_result(_cfg: &crate::config::schema::P2pConfig, _body: &str) {}
+
+#[cfg(not(feature = "p2p"))]
+#[allow(clippy::unused_async)]
+pub async fn publish_to_topic(
+    _cfg: &crate::config::schema::P2pConfig,
+    _topic: &str,
+    _data: &[u8],
+) -> anyhow::Result<()> {
+    anyhow::bail!("p2p feature not enabled at compile time");
+}
+
+#[cfg(not(feature = "p2p"))]
+#[allow(clippy::unused_async)]
+pub async fn put_dht_record(
+    _cfg: &crate::config::schema::P2pConfig,
+    _key: &[u8],
+    _value: &[u8],
+) -> anyhow::Result<()> {
+    anyhow::bail!("p2p feature not enabled at compile time");
+}
+
+#[cfg(not(feature = "p2p"))]
+#[allow(clippy::unused_async)]
+pub async fn get_dht_record(
+    _cfg: &crate::config::schema::P2pConfig,
+    _key: &[u8],
+) -> anyhow::Result<Option<Vec<u8>>> {
+    anyhow::bail!("p2p feature not enabled at compile time");
+}
+
+#[cfg(not(feature = "p2p"))]
+pub fn get_status(_cfg: &crate::config::schema::P2pConfig) -> P2pStatus {
+    P2pStatus {
+        enabled: false,
+        running: false,
+        local_peer_id: None,
+        listen_addresses: Vec::new(),
+        connected_peers: 0,
+        subscribed_topics: Vec::new(),
+    }
+}
+
+// ── Shared helpers ──────────────────────────────────────────────────
+
+pub(crate) fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+/// Parse comma-separated multiaddr bootstrap list into (peer_id, addr) pairs.
+pub fn parse_bootstrap_addrs_from(raw: &str) -> Vec<(String, String)> {
+    raw.split(',')
+        .filter_map(|entry| {
+            let trimmed = entry.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            // Validate it contains /p2p/ component
+            if !trimmed.contains("/p2p/") {
+                tracing::warn!("bootstrap addr missing /p2p/ peer ID component: {trimmed}");
+                return None;
+            }
+            // Extract peer ID from the /p2p/<id> suffix
+            let peer_id = trimmed.rsplit("/p2p/").next().map(|s| s.to_string())?;
+            if peer_id.is_empty() {
+                return None;
+            }
+            Some((peer_id, trimmed.to_string()))
+        })
+        .collect()
+}
+
+/// Sanitize a response string for safe P2P broadcast.
+/// Returns None if the content contains sensitive keywords or is empty.
+pub fn sanitize_for_advisory(response: &str) -> Option<String> {
+    let lower = response.to_ascii_lowercase();
+    let blocked = [
+        "api_key",
+        "token",
+        "password",
+        "secret",
+        "bearer",
+        "credential",
+    ];
+    if blocked.iter().any(|k| lower.contains(k)) {
+        return None;
+    }
+
+    let trimmed = response.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut out = String::new();
+    for ch in trimmed.chars().take(MAX_ADVISORY_PAYLOAD) {
+        out.push(ch);
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advisory_payload_marks_advisory() {
+        let payload = AdvisoryExperimentResult {
+            ts: 1,
+            node: "zeroclaw_node".to_string(),
+            topic: DEFAULT_ADVISORY_TOPIC.to_string(),
+            advisory: true,
+            body: "test-body".to_string(),
+        };
+
+        let json = serde_json::to_value(payload).expect("payload should serialize");
+        assert_eq!(json["advisory"], serde_json::json!(true));
+        assert_eq!(json["topic"], serde_json::json!(DEFAULT_ADVISORY_TOPIC));
+    }
+
+    #[test]
+    fn bootstrap_addr_without_peer_id_is_ignored() {
+        let parsed = parse_bootstrap_addrs_from("/ip4/127.0.0.1/tcp/4001");
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn bootstrap_addr_with_peer_id_is_parsed() {
+        let input = "/ip4/10.0.0.1/tcp/4001/p2p/12D3KooWTestPeerId";
+        let parsed = parse_bootstrap_addrs_from(input);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].0, "12D3KooWTestPeerId");
+        assert_eq!(parsed[0].1, input);
+    }
+
+    #[test]
+    fn bootstrap_multiple_addrs_parsed() {
+        let input = "/ip4/10.0.0.1/tcp/4001/p2p/PeerA, /ip4/10.0.0.2/tcp/4001/p2p/PeerB";
+        let parsed = parse_bootstrap_addrs_from(input);
+        assert_eq!(parsed.len(), 2);
+    }
+
+    #[test]
+    fn sanitize_blocks_sensitive_keywords() {
+        assert!(sanitize_for_advisory("token=abcd").is_none());
+        assert!(sanitize_for_advisory("my api_key is here").is_none());
+        assert!(sanitize_for_advisory("bearer xyz").is_none());
+    }
+
+    #[test]
+    fn sanitize_limits_output_size() {
+        let input = "x".repeat(600);
+        let output = sanitize_for_advisory(&input).expect("sanitized output expected");
+        assert_eq!(output.len(), MAX_ADVISORY_PAYLOAD);
+    }
+
+    #[test]
+    fn sanitize_blocks_empty_input() {
+        assert!(sanitize_for_advisory("").is_none());
+        assert!(sanitize_for_advisory("   ").is_none());
+    }
+
+    #[test]
+    fn sanitize_passes_clean_input() {
+        let output = sanitize_for_advisory("research result: 42Hz resonance detected");
+        assert!(output.is_some());
+    }
+
+    #[test]
+    fn runtime_config_defaults_apply() {
+        let cfg = crate::config::schema::P2pConfig::default();
+        let rt = P2pRuntimeConfig::from_config(&cfg);
+        assert_eq!(rt.listen_addr, DEFAULT_LISTEN_ADDR);
+        assert_eq!(rt.topics, vec![DEFAULT_ADVISORY_TOPIC]);
+        assert_eq!(rt.max_message_size, 1024);
+        assert_eq!(rt.max_peers, 50);
+    }
+
+    #[test]
+    fn p2p_disabled_by_default() {
+        let cfg = crate::config::schema::P2pConfig::default();
+        // Without env var set, should be disabled
+        assert!(!cfg.enabled);
+    }
+}

--- a/src/p2p/runtime.rs
+++ b/src/p2p/runtime.rs
@@ -1,0 +1,521 @@
+//! libp2p runtime: gossipsub pub/sub + Kademlia DHT.
+//!
+//! This module is only compiled when the `p2p` feature is enabled.
+
+use anyhow::{Context, Result};
+use futures_util::StreamExt;
+use libp2p::{
+    gossipsub::{self, IdentTopic, MessageAuthenticity},
+    identify, identity,
+    kad::{self, store::MemoryStore, Record, RecordKey},
+    multiaddr::Protocol,
+    noise,
+    swarm::{NetworkBehaviour, SwarmEvent},
+    tcp, yamux, Multiaddr, PeerId, SwarmBuilder,
+};
+use tokio::sync::{mpsc, oneshot};
+
+use std::collections::{HashMap, HashSet};
+
+use super::{
+    now_unix, p2p_enabled, sanitize_for_advisory, AdvisoryExperimentResult, P2pRuntimeConfig,
+    P2pStatus, DEFAULT_ADVISORY_TOPIC,
+};
+
+// ── Swarm behaviour ────────────────────────────────────────────────
+
+#[derive(NetworkBehaviour)]
+struct P2pBehaviour {
+    gossipsub: gossipsub::Behaviour,
+    kademlia: kad::Behaviour<MemoryStore>,
+    identify: identify::Behaviour,
+}
+
+// ── Commands sent to the swarm task ────────────────────────────────
+
+enum SwarmCommand {
+    /// Publish raw bytes to a gossipsub topic.
+    Publish { topic: String, data: Vec<u8> },
+    /// Store a key-value record in the Kademlia DHT.
+    PutRecord {
+        key: Vec<u8>,
+        value: Vec<u8>,
+        reply: oneshot::Sender<Result<()>>,
+    },
+    /// Retrieve a record from the Kademlia DHT.
+    GetRecord {
+        key: Vec<u8>,
+        reply: oneshot::Sender<Result<Option<Vec<u8>>>>,
+    },
+    /// Query current node status.
+    Status { reply: oneshot::Sender<P2pStatus> },
+}
+
+// ── Singleton state ────────────────────────────────────────────────
+
+struct P2pHandle {
+    cmd_tx: mpsc::Sender<SwarmCommand>,
+    node_id: String,
+    subscribed_topics: Vec<String>,
+}
+
+static HANDLE: tokio::sync::OnceCell<P2pHandle> = tokio::sync::OnceCell::const_new();
+
+// ── Public API ─────────────────────────────────────────────────────
+
+/// Initialize the P2P runtime if enabled. Idempotent — safe to call multiple times.
+pub async fn ensure_runtime_started(cfg: &crate::config::schema::P2pConfig) -> Result<()> {
+    if !p2p_enabled(cfg) {
+        return Ok(());
+    }
+
+    let rt_cfg = P2pRuntimeConfig::from_config(cfg);
+
+    HANDLE
+        .get_or_try_init(|| init_runtime(rt_cfg))
+        .await
+        .map(|_| ())
+}
+
+/// Publish a sanitized advisory message to the default advisory topic.
+pub async fn publish_advisory_result(cfg: &crate::config::schema::P2pConfig, body: &str) {
+    if !p2p_enabled(cfg) {
+        return;
+    }
+
+    let Some(handle) = HANDLE.get() else {
+        return;
+    };
+
+    let Some(sanitized) = sanitize_for_advisory(body) else {
+        return;
+    };
+
+    let payload = AdvisoryExperimentResult {
+        ts: now_unix(),
+        node: handle.node_id.clone(),
+        topic: DEFAULT_ADVISORY_TOPIC.to_string(),
+        advisory: true,
+        body: sanitized,
+    };
+
+    let encoded = match serde_json::to_string(&payload) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let _ = handle
+        .cmd_tx
+        .send(SwarmCommand::Publish {
+            topic: DEFAULT_ADVISORY_TOPIC.to_string(),
+            data: encoded.into_bytes(),
+        })
+        .await;
+}
+
+/// Publish raw data to a specific gossipsub topic.
+pub async fn publish_to_topic(
+    cfg: &crate::config::schema::P2pConfig,
+    topic: &str,
+    data: &[u8],
+) -> Result<()> {
+    if !p2p_enabled(cfg) {
+        anyhow::bail!("p2p is not enabled");
+    }
+
+    let handle = HANDLE.get().context("p2p runtime not started")?;
+
+    handle
+        .cmd_tx
+        .send(SwarmCommand::Publish {
+            topic: topic.to_string(),
+            data: data.to_vec(),
+        })
+        .await
+        .context("p2p runtime channel closed")?;
+
+    Ok(())
+}
+
+/// Store a key-value pair in the Kademlia DHT.
+pub async fn put_dht_record(
+    cfg: &crate::config::schema::P2pConfig,
+    key: &[u8],
+    value: &[u8],
+) -> Result<()> {
+    if !p2p_enabled(cfg) {
+        anyhow::bail!("p2p is not enabled");
+    }
+
+    let handle = HANDLE.get().context("p2p runtime not started")?;
+    let (tx, rx) = oneshot::channel();
+
+    handle
+        .cmd_tx
+        .send(SwarmCommand::PutRecord {
+            key: key.to_vec(),
+            value: value.to_vec(),
+            reply: tx,
+        })
+        .await
+        .context("p2p runtime channel closed")?;
+
+    rx.await.context("p2p runtime dropped reply")?
+}
+
+/// Retrieve a value from the Kademlia DHT by key.
+pub async fn get_dht_record(
+    cfg: &crate::config::schema::P2pConfig,
+    key: &[u8],
+) -> Result<Option<Vec<u8>>> {
+    if !p2p_enabled(cfg) {
+        anyhow::bail!("p2p is not enabled");
+    }
+
+    let handle = HANDLE.get().context("p2p runtime not started")?;
+    let (tx, rx) = oneshot::channel();
+
+    handle
+        .cmd_tx
+        .send(SwarmCommand::GetRecord {
+            key: key.to_vec(),
+            reply: tx,
+        })
+        .await
+        .context("p2p runtime channel closed")?;
+
+    rx.await.context("p2p runtime dropped reply")?
+}
+
+/// Get current P2P node status.
+pub fn get_status(cfg: &crate::config::schema::P2pConfig) -> P2pStatus {
+    let enabled = p2p_enabled(cfg);
+
+    let Some(handle) = HANDLE.get() else {
+        return P2pStatus {
+            enabled,
+            running: false,
+            local_peer_id: None,
+            listen_addresses: Vec::new(),
+            connected_peers: 0,
+            subscribed_topics: handle_topics_or_default(None),
+        };
+    };
+
+    // Try synchronous status query with a short timeout
+    let (tx, rx) = oneshot::channel();
+    if handle
+        .cmd_tx
+        .try_send(SwarmCommand::Status { reply: tx })
+        .is_err()
+    {
+        return P2pStatus {
+            enabled,
+            running: true,
+            local_peer_id: None,
+            listen_addresses: Vec::new(),
+            connected_peers: 0,
+            subscribed_topics: handle.subscribed_topics.clone(),
+        };
+    }
+
+    // Block briefly for the reply — this runs in an async context so it's fine
+    match rx.blocking_recv() {
+        Ok(status) => status,
+        Err(_) => P2pStatus {
+            enabled,
+            running: true,
+            local_peer_id: None,
+            listen_addresses: Vec::new(),
+            connected_peers: 0,
+            subscribed_topics: handle.subscribed_topics.clone(),
+        },
+    }
+}
+
+fn handle_topics_or_default(topics: Option<&[String]>) -> Vec<String> {
+    topics
+        .map(|t| t.to_vec())
+        .unwrap_or_else(|| vec![DEFAULT_ADVISORY_TOPIC.to_string()])
+}
+
+// ── Runtime initialization ─────────────────────────────────────────
+
+async fn init_runtime(rt_cfg: P2pRuntimeConfig) -> Result<P2pHandle> {
+    let listen_addr: Multiaddr = rt_cfg
+        .listen_addr
+        .parse()
+        .context("invalid p2p listen address")?;
+
+    let key = identity::Keypair::generate_ed25519();
+    let local_peer_id = PeerId::from(key.public());
+
+    // Build gossipsub
+    let gossip_cfg = gossipsub::ConfigBuilder::default()
+        .validation_mode(gossipsub::ValidationMode::Strict)
+        .max_transmit_size(rt_cfg.max_message_size)
+        .build()
+        .context("failed to build gossipsub config")?;
+
+    let mut gossipsub_behaviour =
+        gossipsub::Behaviour::new(MessageAuthenticity::Signed(key.clone()), gossip_cfg)
+            .map_err(|e| anyhow::anyhow!("failed to construct gossipsub: {e}"))?;
+
+    // Subscribe to configured topics
+    let mut subscribed_topics = Vec::new();
+    for topic_str in &rt_cfg.topics {
+        let topic = IdentTopic::new(topic_str);
+        gossipsub_behaviour
+            .subscribe(&topic)
+            .context(format!("failed to subscribe to topic: {topic_str}"))?;
+        subscribed_topics.push(topic_str.clone());
+    }
+
+    // Build Kademlia
+    let store = MemoryStore::new(local_peer_id);
+    let kademlia = kad::Behaviour::new(local_peer_id, store);
+
+    // Build identify (helps peers exchange listen addresses)
+    let identify_behaviour = identify::Behaviour::new(identify::Config::new(
+        "/zeroclaw/0.1.0".to_string(),
+        key.public(),
+    ));
+
+    // Build swarm
+    let mut swarm = SwarmBuilder::with_existing_identity(key)
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )
+        .context("failed to build tcp transport")?
+        .with_behaviour(|_| P2pBehaviour {
+            gossipsub: gossipsub_behaviour,
+            kademlia,
+            identify: identify_behaviour,
+        })
+        .context("failed to build p2p behaviour")?
+        .build();
+
+    swarm
+        .listen_on(listen_addr)
+        .context("failed to bind p2p listen address")?;
+
+    // Add bootstrap peers to Kademlia routing table
+    for addr_str in &rt_cfg.bootstrap_peers {
+        if let Ok(addr) = addr_str.parse::<Multiaddr>() {
+            if let Some(peer_id) = extract_peer_id(&addr) {
+                swarm.behaviour_mut().kademlia.add_address(&peer_id, addr);
+            }
+        }
+    }
+
+    // Kick off Kademlia bootstrap if we have bootstrap peers
+    if !rt_cfg.bootstrap_peers.is_empty() {
+        if let Err(e) = swarm.behaviour_mut().kademlia.bootstrap() {
+            tracing::warn!("kademlia bootstrap failed: {e}");
+        }
+    }
+
+    let (cmd_tx, cmd_rx) = mpsc::channel::<SwarmCommand>(256);
+    let topics_clone = subscribed_topics.clone();
+    let node_id = rt_cfg.node_id.clone();
+
+    // Spawn the swarm event loop
+    tokio::spawn(swarm_loop(
+        swarm,
+        cmd_rx,
+        local_peer_id,
+        topics_clone.clone(),
+    ));
+
+    tracing::info!(
+        peer_id = %local_peer_id,
+        topics = ?topics_clone,
+        "p2p runtime initialized"
+    );
+
+    Ok(P2pHandle {
+        cmd_tx,
+        node_id,
+        subscribed_topics,
+    })
+}
+
+fn extract_peer_id(addr: &Multiaddr) -> Option<PeerId> {
+    addr.iter().find_map(|part| match part {
+        Protocol::P2p(peer_id) => Some(peer_id),
+        _ => None,
+    })
+}
+
+// ── Swarm event loop ───────────────────────────────────────────────
+
+async fn swarm_loop(
+    mut swarm: libp2p::Swarm<P2pBehaviour>,
+    mut cmd_rx: mpsc::Receiver<SwarmCommand>,
+    local_peer_id: PeerId,
+    subscribed_topics: Vec<String>,
+) {
+    // Track pending DHT get queries
+    let mut pending_get_queries: HashMap<kad::QueryId, oneshot::Sender<Result<Option<Vec<u8>>>>> =
+        HashMap::new();
+    let mut pending_put_queries: HashMap<kad::QueryId, oneshot::Sender<Result<()>>> =
+        HashMap::new();
+    let mut listen_addresses: Vec<String> = Vec::new();
+    let mut connected_peers: HashSet<PeerId> = HashSet::new();
+
+    loop {
+        tokio::select! {
+            cmd = cmd_rx.recv() => {
+                match cmd {
+                    Some(SwarmCommand::Publish { topic, data }) => {
+                        let ident_topic = IdentTopic::new(&topic);
+                        if let Err(err) = swarm.behaviour_mut().gossipsub.publish(ident_topic, data) {
+                            tracing::warn!("p2p gossip publish to {topic} failed: {err}");
+                        }
+                    }
+                    Some(SwarmCommand::PutRecord { key, value, reply }) => {
+                        let record = Record {
+                            key: RecordKey::new(&key),
+                            value,
+                            publisher: None,
+                            expires: None,
+                        };
+                        match swarm.behaviour_mut().kademlia.put_record(record, kad::Quorum::One) {
+                            Ok(query_id) => {
+                                pending_put_queries.insert(query_id, reply);
+                            }
+                            Err(e) => {
+                                let _ = reply.send(Err(anyhow::anyhow!("kademlia put failed: {e}")));
+                            }
+                        }
+                    }
+                    Some(SwarmCommand::GetRecord { key, reply }) => {
+                        let query_id = swarm.behaviour_mut().kademlia.get_record(RecordKey::new(&key));
+                        pending_get_queries.insert(query_id, reply);
+                    }
+                    Some(SwarmCommand::Status { reply }) => {
+                        let status = P2pStatus {
+                            enabled: true,
+                            running: true,
+                            local_peer_id: Some(local_peer_id.to_string()),
+                            listen_addresses: listen_addresses.clone(),
+                            connected_peers: connected_peers.len(),
+                            subscribed_topics: subscribed_topics.clone(),
+                        };
+                        let _ = reply.send(status);
+                    }
+                    None => break,
+                }
+            }
+            event = swarm.select_next_some() => {
+                match event {
+                    SwarmEvent::NewListenAddr { address, .. } => {
+                        let addr_str = address.to_string();
+                        tracing::info!("p2p listening on {addr_str}");
+                        listen_addresses.push(addr_str);
+                    }
+                    SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                        connected_peers.insert(peer_id);
+                        tracing::debug!("p2p peer connected: {peer_id}");
+                    }
+                    SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                        connected_peers.remove(&peer_id);
+                        tracing::debug!("p2p peer disconnected: {peer_id}");
+                    }
+
+                    // Gossipsub events
+                    SwarmEvent::Behaviour(P2pBehaviourEvent::Gossipsub(
+                        gossipsub::Event::Message { message, .. },
+                    )) => {
+                        let source = message
+                            .source
+                            .map_or_else(|| "unknown".to_string(), |p| p.to_string());
+                        let topic = message.topic.to_string();
+                        tracing::debug!(
+                            from = %source,
+                            topic = %topic,
+                            bytes = message.data.len(),
+                            "p2p gossip message received"
+                        );
+                    }
+
+                    // Kademlia events
+                    SwarmEvent::Behaviour(P2pBehaviourEvent::Kademlia(
+                        kad::Event::OutboundQueryProgressed { id, result, .. },
+                    )) => {
+                        match result {
+                            kad::QueryResult::GetRecord(Ok(
+                                kad::GetRecordOk::FoundRecord(kad::PeerRecord { record, .. }),
+                            )) => {
+                                if let Some(reply) = pending_get_queries.remove(&id) {
+                                    let _ = reply.send(Ok(Some(record.value)));
+                                }
+                            }
+                            kad::QueryResult::GetRecord(Ok(
+                                kad::GetRecordOk::FinishedWithNoAdditionalRecord { .. },
+                            )) => {
+                                // Only reply if we haven't already (from FoundRecord)
+                                if let Some(reply) = pending_get_queries.remove(&id) {
+                                    let _ = reply.send(Ok(None));
+                                }
+                            }
+                            kad::QueryResult::GetRecord(Err(e)) => {
+                                if let Some(reply) = pending_get_queries.remove(&id) {
+                                    let _ = reply.send(Err(anyhow::anyhow!(
+                                        "kademlia get failed: {e:?}"
+                                    )));
+                                }
+                            }
+                            kad::QueryResult::PutRecord(Ok(_)) => {
+                                if let Some(reply) = pending_put_queries.remove(&id) {
+                                    let _ = reply.send(Ok(()));
+                                }
+                            }
+                            kad::QueryResult::PutRecord(Err(e)) => {
+                                if let Some(reply) = pending_put_queries.remove(&id) {
+                                    let _ = reply.send(Err(anyhow::anyhow!(
+                                        "kademlia put failed: {e:?}"
+                                    )));
+                                }
+                            }
+                            kad::QueryResult::Bootstrap(Ok(_)) => {
+                                tracing::info!("kademlia bootstrap completed");
+                            }
+                            kad::QueryResult::Bootstrap(Err(e)) => {
+                                tracing::warn!("kademlia bootstrap error: {e:?}");
+                            }
+                            _ => {}
+                        }
+                    }
+                    SwarmEvent::Behaviour(P2pBehaviourEvent::Kademlia(
+                        kad::Event::RoutingUpdated { peer, .. },
+                    )) => {
+                        tracing::debug!("kademlia routing updated for peer: {peer}");
+                    }
+
+                    // Identify events — add discovered addresses to Kademlia
+                    SwarmEvent::Behaviour(P2pBehaviourEvent::Identify(
+                        identify::Event::Received { peer_id, info, .. },
+                    )) => {
+                        for addr in &info.listen_addrs {
+                            swarm
+                                .behaviour_mut()
+                                .kademlia
+                                .add_address(&peer_id, addr.clone());
+                        }
+                        tracing::debug!(
+                            peer = %peer_id,
+                            addrs = info.listen_addrs.len(),
+                            "identify: discovered peer addresses"
+                        );
+                    }
+
+                    _ => {}
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Restore the previously-removed P2P subsystem (gossipsub pub/sub + Kademlia DHT) so the runtime can opt-in to decentralized messaging and DHT storage. 
- Keep P2P opt-in and secure-by-default via a feature gate and runtime `enabled` flag, and ensure startup fails fast when explicitly enabled but misconfigured. 

### Description

- Reintroduced P2P module files: added `src/p2p/mod.rs` (helpers, stubs, config/runtime types, sanitizer, tests) and `src/p2p/runtime.rs` (feature-gated libp2p runtime: gossipsub + Kademlia swarm, event loop, publish/put/get API). 
- Rewired binary/library entrypoints by exporting/loading P2P: added `pub mod p2p;` in `src/lib.rs` and `mod p2p;` in `src/main.rs`. 
- Wired startup hooks to initialize P2P for long-running paths by calling `p2p::ensure_runtime_started(&config.p2p)` during `agent` and `daemon` startup with explicit context errors on failure. 
- Restored configuration schema: added `P2pConfig` and `pub p2p: P2pConfig` in `src/config/schema.rs` with secure defaults (`enabled: false`, sensible listen/bootstrap/topics/limits). 
- Restored dependency & feature graph in `Cargo.toml`: added optional `libp2p` dependency and a `p2p` feature that depends on it, keeping P2P strictly opt-in at compile time. 
- Added no-op/stub implementations for publish/put/get/status when the `p2p` feature is not enabled so the rest of the codebase can call P2P APIs safely when compiled without the feature. 

### Testing

- Ran `cargo fmt --all -- --check`; this reported a pre-existing manifest/test-target mismatch (missing test target files) causing the check to fail. 
- Ran `cargo clippy --all-targets -- -D warnings`; the run was blocked by environment/network access errors when fetching the crates.io index (network 403), so lint verification could not complete. 
- Ran `cargo test` and `cargo test --features p2p`; both were blocked by the same crates.io index/network error and did not complete. 
- Ran `cargo check` variants (`--no-default-features`, `--no-default-features --features p2p`); these were also blocked by the crates.io/network error. 

All attempted automated checks either failed due to pre-existing project manifest/test-target issues or were blocked by an external crates.io/network fetch error; no new test regressions in P2P unit tests were observed locally because the full build/test runs could not complete in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2fb39e248332b7dbd52749f40682)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
