### PR TITLE
docs: Add comprehensive documentation and SEO infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# R.A.I.N. Lab: Mathematically-Verified Autonomous Research
-
-**James🐙**
+# R.A.I.N. Lab: A Local-First Research Assistant That Verifies Its Own Answers
 
 <p align="center">
   <img src="assets/rain_lab.png" alt="R.A.I.N. Lab logo" width="900" />
@@ -14,7 +12,7 @@
 </p>
 
 <p align="center">
-  <strong>🌐 Read this in:</strong>
+  <strong>Read this in:</strong>
   <a href="README.zh-CN.md">中文</a> ·
   <a href="README.ja.md">日本語</a> ·
   <a href="README.ru.md">Русский</a> ·
@@ -22,9 +20,7 @@
   <a href="README.vi.md">Tiếng Việt</a>
 </p>
 
-R.A.I.N. Lab is a research assistant that runs entirely on your own computer. You ask it a question, and instead of giving you one answer that might be wrong, it launches a team of AI agents that debate each other, poke holes in each other's logic, and — when they get stuck — settle the argument with mathematical proof.
-
-**The result: answers you can actually trust, with your data never leaving your machine.**
+R.A.I.N. Lab is an open-source multi-agent research assistant built for **academic researchers, R&D teams, and privacy-conscious organizations** who need AI-generated conclusions they can actually trust. It solves the fundamental problem with multi-agent AI — agents that either agree too quickly or argue in circles forever — by automatically settling unresolved debates with mathematical proof via a sandboxed SAT solver. It runs entirely on your own computer, and your data never leaves your machine.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,75 @@
+# R.A.I.N. Lab: A Local-First Research Assistant That Verifies Its Own Answers
+
+R.A.I.N. Lab is an open-source multi-agent research assistant for **academic researchers, R&D teams, and privacy-conscious organizations** who need AI-generated conclusions they can actually trust. It solves the core problem with multi-agent AI systems — agents that either agree too quickly or argue forever — by automatically translating unresolved debates into formal logic and settling them with a mathematically guaranteed SAT solver running inside a secure sandbox.
+
+**Your data never leaves your machine. Every conclusion comes with proof, not probability.**
+
+---
+
+## How It Works
+
+1. **Explore** — Specialist AI agents investigate your research question from different angles.
+2. **Debate** — Agents challenge each other's reasoning across multiple rounds.
+3. **Verify** — When debate stalls, the system compiles the disagreement into a boolean formula and solves it with a WASM-sandboxed SAT solver.
+4. **Resolve** — The proven result is injected back, forcing agents to build on settled facts.
+
+This is the **Circuit Breaker architecture**: instead of guessing, R.A.I.N. Lab proves.
+
+---
+
+## Who Is This For?
+
+- **Academic Researchers** — Run automated, adversarial peer review on your thesis against a local library of papers before human review.
+- **Math & Physics R&D** — Use the plugin system to let AI run formal verification with Lean, Coq, or custom Rust physics engines.
+- **Privacy-Conscious Teams** — Analyze sensitive datasets without sending a single byte to an external API.
+
+---
+
+## Quick Start
+
+```bash
+git clone https://github.com/topherchris420/james_library.git
+cd james_library
+python bootstrap_local.py
+python rain_lab.py
+```
+
+See the [full installation guide](../README.md#install-in-3-steps) for platform-specific instructions.
+
+---
+
+## Architecture
+
+R.A.I.N. Lab ships as one product built from two layers:
+
+| Layer | Role | Language |
+|---|---|---|
+| **James Library** | Research workflows, lab meetings, synthesis | Python |
+| **ZeroClaw** | Agent runtime, orchestration, security, tools | Rust (optional) |
+
+Python research workflows work without Rust. The Rust runtime adds speed, channels, and tool execution for advanced users.
+
+---
+
+## Key Features
+
+- **3.1 MB core binary** — runs on laptops, desktops, and low-powered devices
+- **Full local encryption** — all conversations and files stored locally
+- **Hot-loadable plugins** — add custom solvers and physics engines without restart
+- **Multi-model support** — LM Studio, OpenRouter, OpenAI, and more
+- **3D visualization** — optional Godot-based avatar interface
+
+---
+
+## Documentation
+
+- [Commands Reference](commands-reference.md)
+- [Configuration Reference](config-reference.md)
+- [Providers Reference](providers-reference.md)
+- [Channels Reference](channels-reference.md)
+- [Troubleshooting](troubleshooting.md)
+- [Operations Runbook](operations-runbook.md)
+
+## License
+
+MIT OR Apache-2.0

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "R.A.I.N. Lab",
+  "alternateName": ["James Library", "ZeroClaw"],
+  "applicationCategory": "DeveloperApplication",
+  "applicationSubCategory": "Research Assistant",
+  "description": "An open-source, local-first multi-agent research assistant that uses mathematical verification (SAT solving) to break deadlocks in AI debates and produce trustworthy, research-grade conclusions.",
+  "operatingSystem": ["Windows", "macOS", "Linux"],
+  "license": "https://opensource.org/licenses/MIT",
+  "isAccessibleForFree": true,
+  "url": "https://github.com/topherchris420/james_library",
+  "codeRepository": "https://github.com/topherchris420/james_library",
+  "programmingLanguage": ["Python", "Rust"],
+  "runtimePlatform": "Python 3.10+",
+  "softwareRequirements": "Python 3.10 or newer",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "author": {
+    "@type": "Organization",
+    "name": "ZeroClaw Labs",
+    "url": "https://github.com/topherchris420"
+  },
+  "keywords": [
+    "multi-agent AI",
+    "research assistant",
+    "mathematical verification",
+    "SAT solver",
+    "local-first AI",
+    "privacy-preserving AI",
+    "autonomous research",
+    "AI debate system",
+    "formal verification"
+  ],
+  "featureList": [
+    "Multi-agent adversarial debate with automatic deadlock resolution",
+    "Mathematical verification via WASM-sandboxed SAT solver",
+    "Local-first architecture with full data encryption",
+    "Plugin system for custom solvers and physics engines",
+    "Multi-model support (LM Studio, OpenRouter, OpenAI)",
+    "3D avatar visualization via Godot client"
+  ]
+}
+</script>
+{% endblock %}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,58 @@
+# R.A.I.N. Lab
+
+> R.A.I.N. Lab is an open-source, local-first multi-agent research assistant that uses mathematical verification to produce trustworthy answers.
+
+## What it does
+
+R.A.I.N. Lab launches a team of AI agents that debate each other's reasoning. When agents get stuck in a loop or disagree, the system automatically translates the disagreement into a formal logic problem and solves it with a SAT solver running inside a secure WebAssembly sandbox. The proven result is injected back into the conversation, forcing the agents to accept the settled fact and move forward. This is called the "Circuit Breaker" architecture.
+
+## Who it is for
+
+- Academic researchers who want automated, adversarial peer review of their work before human review.
+- Math and physics R&D teams who need AI-assisted research with formal verification (Lean, Coq, custom solvers).
+- Privacy-conscious organizations that need to analyze sensitive data without sending anything to external APIs.
+
+## What problem it solves
+
+Most multi-agent AI systems either agree too quickly (groupthink) or argue in circles forever. R.A.I.N. Lab breaks deadlocks with mathematical proof, producing research-grade conclusions instead of best-guess answers. All data stays on the user's machine.
+
+## How it works
+
+1. Specialist agents explore different angles of a research question (using UCB1-Bandit exploration).
+2. Agents debate in multiple rounds, challenging each other's reasoning.
+3. When the system detects circular debate, it compiles the disagreement into a boolean formula and runs a DPLL SAT solver in a WASM sandbox.
+4. The proven result is injected as a SYSTEM_OVERRIDE, forcing agents to build on settled facts.
+
+## Architecture
+
+R.A.I.N. Lab is built from two layers:
+
+- James Library (Python): Research workflows, lab meetings, synthesis, acoustic physics simulations.
+- ZeroClaw (Rust): Agent runtime, orchestration, tool execution, channels, memory, security. Optional but adds speed and advanced features.
+
+Python research workflows work without Rust installed.
+
+## Key features
+
+- Runs entirely locally on laptops, desktops, or low-powered devices (3.1 MB core binary).
+- All data encrypted and stored locally. Nothing sent to the cloud unless you connect a cloud provider.
+- Extensible plugin system for custom solvers, physics engines, and tools (hot-loaded, no restart).
+- Multi-model support: works with LM Studio, OpenRouter, OpenAI, and other providers.
+- 3D avatar visualization via Godot client.
+
+## Tech stack
+
+- Python 3.10+ (research workflows)
+- Rust 1.87+ (optional runtime)
+- WebAssembly (verification sandbox)
+- MkDocs Material (documentation)
+
+## License
+
+MIT OR Apache-2.0
+
+## Links
+
+- Repository: https://github.com/topherchris420/james_library
+- Documentation: docs/README.md
+- Getting started: Run `python bootstrap_local.py` then `python rain_lab.py`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: R.A.I.N. Lab Documentation
 site_description: Enterprise-grade epistemic laboratory and multi-agent architecture.
 theme:
   name: material
+  custom_dir: docs/overrides
   logo: assets/rain_lab_logo.png
   favicon: assets/rain_lab_logo.png
   palette:

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,28 @@
+# R.A.I.N. Lab - Crawler Policy
+# Allow AI crawlers to index project documentation
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: *
+Allow: /
+
+Sitemap: https://topherchris420.github.io/james_library/sitemap.xml


### PR DESCRIPTION
## Summary

- **Base branch target:** `dev`
- **Problem:** R.A.I.N. Lab lacks comprehensive user-facing documentation, SEO metadata, and crawler policies needed for discoverability and accessibility.
- **Why it matters:** Documentation is critical for onboarding users, explaining the Circuit Breaker architecture, and establishing the project's credibility in academic/R&D communities. SEO infrastructure ensures the project is discoverable by researchers and organizations who need it.
- **What changed:** Added `docs/index.md` (landing page), `llms.txt` (LLM-friendly project summary), `docs/overrides/main.html` (Schema.org structured data), `robots.txt` (crawler policy), and updated `README.md` and `mkdocs.yml` to integrate documentation.
- **What did not change:** No source code, runtime behavior, or configuration logic modified. This is purely documentation and metadata infrastructure.

---

## Label Snapshot

- **Risk label:** `risk: low`
- **Size label:** `size: S`
- **Scope labels:** `docs`
- **Module labels:** N/A
- **Contributor tier label:** Auto-managed
- **Auto-label corrections:** None

---

## Change Metadata

- **Change type:** `docs`
- **Primary scope:** `docs`

---

## Linked Issue

- Closes: (none — foundational documentation work)
- Related: (none)

---

## Validation Evidence

No code changes; documentation and metadata only. No CI validation required beyond MkDocs build verification (if configured).

- Evidence provided: N/A
- Intentionally skipped: Cargo tests (not applicable to documentation)

---

## Security Impact

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

---

## Privacy and Data Hygiene

- **Data-hygiene status:** `pass`
- **Redaction/anonymization notes:** None — documentation contains only public project information.
- **Neutral wording confirmation:** All wording uses project-native labels (R.A.I.N. Lab, James Library, ZeroClaw, Circuit Breaker architecture).

---

## Compatibility / Migration

- **Backward compatible?** `Yes` — documentation additions do not affect runtime.
- **Config/env changes?** `No`
- **Migration needed?** `No`

---

## i18n Follow-Through

- **i18n follow-through triggered?** `Yes` — README.md wording updated; locale navigation parity maintained.
- **Locale navigation parity updated?** `Yes` — Language links in README.md preserved (`中文`, `日本語`, `Русский`, `Français`, `Tiếng Việt`).
- **Localized runtime-contract docs updated?** `N.A.` — This PR adds landing documentation only; localized command/config references are out of scope.
- **Follow-up:** Localized `docs/i18n/*/index.md` and equivalent reference docs should be added in a follow-up PR.

---

## Human Verification

- **Verified scenarios:** README.md landing page clarity, documentation structure in `mkdocs.yml`, Schema.org JSON-LD validity for search engines.
- **Edge cases checked:** Crawler policy covers major AI indexers (GPTBot, ClaudeBot, PerplexityBot) and standard bots (Googlebot, Bingbot).
- **What was not verified:** Actual MkDocs build output (assumes `mkdocs build` passes in CI).

---

## Side Effects / Blast Radius

- **Affected subsystems/workflows:** Documentation site generation; SEO indexing; LLM context windows (via `llms.txt`).
- **Potential unintended effects:** None identified.
- **Guardrails/monitoring:** Standard MkDocs build validation in CI.

---

## Rollback Plan

- **Fast rollback command:** `git revert <commit-hash>`
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** MkDocs build failure or broken documentation links (caught by CI

https://claude.ai/code/session_01R8DSsHbgns4mm66qjyFh11
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/156" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
