### PR TITLE
ci(governance): add deterministic docs parity and architecture boundary checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,18 @@
 name: CI
+
 permissions:
   contents: read
+
 on:
   push:
-      - '**'
+    branches:
+      - "**"
   pull_request:
     branches: [dev, main]
 
 concurrency:
-  group: ci-py-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-  pull_request:
-    branches: [dev, main]
 
 jobs:
   lint-and-test:
@@ -39,3 +40,45 @@ jobs:
           fi
       - run: ruff check . --output-format=full
       - run: pytest tests/ -v -ra --tb=long
+
+  governance-contracts:
+    name: Governance Contract Checks
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect governance-relevant changes
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "$BASE_SHA" ]; then
+            echo "run_checks=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED_FILES="$(git diff --name-only "$BASE_SHA" HEAD || true)"
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "run_checks=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if printf '%s\n' "$CHANGED_FILES" | rg -q '^(src/|README\.md$|README\.(zh-CN|ja|ru|fr|vi)\.md$|docs/README\.md$|docs/README\.(zh-CN|ja|ru|fr)\.md$|docs/i18n/vi/README\.md$|docs/SUMMARY\.md$)'; then
+            echo "run_checks=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_checks=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Docs parity check
+        if: steps.scope.outputs.run_checks == 'true'
+        run: scripts/ci/docs_parity_check.sh
+
+      - name: Architecture boundary check
+        if: steps.scope.outputs.run_checks == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: scripts/ci/arch_boundary_check.sh

--- a/docs/contributing/reviewer-playbook.md
+++ b/docs/contributing/reviewer-playbook.md
@@ -109,7 +109,22 @@ For high-risk PRs, verify at least one concrete example in each category:
 - **Observability:** failures are diagnosable without leaking secrets.
 - **Rollback safety:** revert path and blast radius are clear.
 
-### 3.4 Review comment outcome style
+### 3.4 CI failure remediation (governance contracts)
+
+If a PR fails the governance contract checks, ask the contributor to run the same scripts locally before requesting re-review:
+
+```bash
+scripts/ci/docs_parity_check.sh
+BASE_SHA=<target-base-sha> scripts/ci/arch_boundary_check.sh
+```
+
+Quick remediation guide:
+
+- **`docs_parity_check.sh` failure:** ensure README/docs hub/SUMMARY entries stay aligned for `en`, `zh-CN`, `ja`, `ru`, `fr`, `vi` (root README files, docs hubs, and summary links).
+- **`arch_boundary_check.sh` failure:** remove newly introduced cross-subsystem imports and re-route dependencies through traits/public facades (no provider↔channel internals, no tool↔gateway coupling).
+- Re-run both scripts after fixes and include command output in the PR validation notes.
+
+### 3.5 Review comment outcome style
 
 Prefer checklist-style comments with one explicit outcome:
 

--- a/scripts/ci/arch_boundary_check.sh
+++ b/scripts/ci/arch_boundary_check.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+BASE_SHA="${BASE_SHA:-}"
+if [ -z "$BASE_SHA" ] || ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+  echo "[arch-boundary] BASE_SHA is missing or invalid; comparing HEAD~1..HEAD."
+  DIFF_BASE="HEAD~1"
+else
+  DIFF_BASE="$BASE_SHA"
+fi
+
+if ! git rev-parse --verify "$DIFF_BASE" >/dev/null 2>&1; then
+  echo "[arch-boundary] Unable to resolve diff base '$DIFF_BASE'; skipping."
+  exit 0
+fi
+
+if [ -z "$(git diff --name-only "$DIFF_BASE" HEAD -- src/*.rs src/**/*.rs || true)" ]; then
+  echo "[arch-boundary] No changed Rust source files detected; skipping boundary checks."
+  exit 0
+fi
+
+violations=0
+
+check_diff_for_pattern() {
+  local pathspec="$1"
+  local regex="$2"
+  local message="$3"
+
+  local output
+  output="$(git diff --unified=0 --no-color "$DIFF_BASE" HEAD -- "$pathspec" | rg -n "^\+[^+].*${regex}" || true)"
+
+  if [ -n "$output" ]; then
+    echo "[arch-boundary] $message"
+    echo "$output"
+    violations=$((violations + 1))
+  fi
+}
+
+check_channel_provider_internal() {
+  local output
+  output="$(git diff --unified=0 --no-color "$DIFF_BASE" HEAD -- 'src/channels/**/*.rs' \
+    | rg -n '^\+[^+].*crate::providers::[a-zA-Z0-9_]+::' \
+    | rg -v 'crate::providers::traits::' || true)"
+
+  if [ -n "$output" ]; then
+    echo "[arch-boundary] Forbidden channel→provider internal import detected (channels may not depend on provider internals)."
+    echo "$output"
+    violations=$((violations + 1))
+  fi
+}
+
+check_diff_for_pattern \
+  'src/providers/**/*.rs' \
+  'crate::channels::[a-zA-Z0-9_]+::' \
+  'Forbidden provider→channel internal import detected (providers must not depend on channel internals).'
+
+check_channel_provider_internal
+
+check_diff_for_pattern \
+  'src/tools/**/*.rs' \
+  'crate::gateway::' \
+  'Forbidden tool→gateway coupling detected (tools must not import gateway internals/policy paths).'
+
+check_diff_for_pattern \
+  'src/gateway/**/*.rs' \
+  'crate::tools::' \
+  'Forbidden gateway→tool coupling detected (gateway must not import tool internals).'
+
+if [ "$violations" -ne 0 ]; then
+  cat <<'GUIDE'
+[arch-boundary] Remediation:
+  1) Move shared contracts into trait/facade modules.
+  2) Depend on traits/public factory registration instead of concrete subsystem internals.
+  3) Keep gateway policy decisions inside gateway/security boundaries, not tool modules.
+GUIDE
+  exit 1
+fi
+
+echo "[arch-boundary] Architecture boundary checks passed."

--- a/scripts/ci/docs_parity_check.sh
+++ b/scripts/ci/docs_parity_check.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+failures=0
+
+check_file_exists() {
+  local path="$1"
+  if [ ! -f "$path" ]; then
+    echo "[docs-parity] Missing required file: $path"
+    failures=$((failures + 1))
+  fi
+}
+
+check_contains() {
+  local path="$1"
+  local pattern="$2"
+  local hint="$3"
+  if ! grep -Fq "$pattern" "$path"; then
+    echo "[docs-parity] $path is missing expected reference: $hint"
+    failures=$((failures + 1))
+  fi
+}
+
+ROOT_READMES=(
+  "README.md"
+  "README.zh-CN.md"
+  "README.ja.md"
+  "README.ru.md"
+  "README.fr.md"
+  "README.vi.md"
+)
+
+DOCS_HUBS=(
+  "docs/README.md"
+  "docs/README.zh-CN.md"
+  "docs/README.ja.md"
+  "docs/README.ru.md"
+  "docs/README.fr.md"
+  "docs/i18n/vi/README.md"
+)
+
+for file in "${ROOT_READMES[@]}"; do
+  check_file_exists "$file"
+done
+
+for file in "${DOCS_HUBS[@]}"; do
+  check_file_exists "$file"
+done
+
+check_file_exists "docs/SUMMARY.md"
+
+# Root README locale switcher should include all localized root READMEs.
+check_contains "README.md" "README.zh-CN.md" "README.zh-CN.md"
+check_contains "README.md" "README.ja.md" "README.ja.md"
+check_contains "README.md" "README.ru.md" "README.ru.md"
+check_contains "README.md" "README.fr.md" "README.fr.md"
+check_contains "README.md" "README.vi.md" "README.vi.md"
+
+# English docs hub should expose all supported locale hubs.
+check_contains "docs/README.md" "README.zh-CN.md" "docs/README.zh-CN.md"
+check_contains "docs/README.md" "README.ja.md" "docs/README.ja.md"
+check_contains "docs/README.md" "README.ru.md" "docs/README.ru.md"
+check_contains "docs/README.md" "README.fr.md" "docs/README.fr.md"
+check_contains "docs/README.md" "i18n/vi/README.md" "docs/i18n/vi/README.md"
+
+# Unified docs summary should include both root README and docs hub links for required locales.
+SUMMARY_FILE="docs/SUMMARY.md"
+check_contains "$SUMMARY_FILE" "../README.md" "English root README"
+check_contains "$SUMMARY_FILE" "../README.zh-CN.md" "Chinese root README"
+check_contains "$SUMMARY_FILE" "../README.ja.md" "Japanese root README"
+check_contains "$SUMMARY_FILE" "../README.ru.md" "Russian root README"
+check_contains "$SUMMARY_FILE" "../README.fr.md" "French root README"
+check_contains "$SUMMARY_FILE" "../README.vi.md" "Vietnamese root README"
+
+check_contains "$SUMMARY_FILE" "README.md" "English docs hub"
+check_contains "$SUMMARY_FILE" "README.zh-CN.md" "Chinese docs hub"
+check_contains "$SUMMARY_FILE" "README.ja.md" "Japanese docs hub"
+check_contains "$SUMMARY_FILE" "README.ru.md" "Russian docs hub"
+check_contains "$SUMMARY_FILE" "README.fr.md" "French docs hub"
+check_contains "$SUMMARY_FILE" "README.vi.md" "Vietnamese docs hub link"
+
+if [ "$failures" -ne 0 ]; then
+  echo "[docs-parity] Failed with $failures parity issue(s)."
+  exit 1
+fi
+
+echo "[docs-parity] README/docs-hub/SUMMARY parity checks passed for en, zh-CN, ja, ru, fr, vi."


### PR DESCRIPTION
### Motivation

- Make governance-sensitive contracts (docs navigation and architecture boundaries) self-verifiable and deterministic in CI to reduce reviewer latency.
- Prevent accidental regressions to locale parity (README/docs hub/SUMMARY) that break documentation navigation across supported locales.
- Catch forbidden cross-subsystem imports early (provider↔channel internals, tool↔gateway coupling) to preserve the trait/facade architecture contract.

### Description

- Added `scripts/ci/docs_parity_check.sh` to verify presence of root `README.*` files, docs hub files and `docs/SUMMARY.md` references for `en`, `zh-CN`, `ja`, `ru`, `fr`, and `vi`, and to fail fast on missing/misaligned entries.
- Added `scripts/ci/arch_boundary_check.sh` to scan PR diffs (via `BASE_SHA`) and flag newly introduced forbidden imports: provider→channel internals, channel→provider internals (except `providers::traits`), tool→gateway imports, and gateway→tool imports, with remediation guidance on failure.
- Wired both scripts into `.github/workflows/ci.yml` as a non-optional `Governance Contract Checks` job that runs for pull requests whose changed files match `src/**` or the docs entry points (`README.md`/localized README files, `docs/README.*`, `docs/i18n/vi/README.md`, or `docs/SUMMARY.md`).
- Added concise remediation instructions to `docs/contributing/reviewer-playbook.md` showing how contributors can run `scripts/ci/docs_parity_check.sh` and `BASE_SHA=<target-base-sha> scripts/ci/arch_boundary_check.sh` locally and fix common failures.

### Testing

- Ran a syntax check of the new scripts with `bash -n scripts/ci/docs_parity_check.sh scripts/ci/arch_boundary_check.sh`, which succeeded.
- Executed `scripts/ci/docs_parity_check.sh` locally, which passed for the current repository state.
- Executed `BASE_SHA=$(git rev-parse HEAD~1) scripts/ci/arch_boundary_check.sh` locally, which passed (or reported no changed Rust files to scan).
- Ran unit tests with `python -m pytest tests/ -q`, producing `253 passed, 1 skipped`.
- Ran `ruff check . --output-format=full`, which failed due to existing repository-wide lint issues unrelated to these added governance checks (pre-existing lint debt outside this change set).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03ec5e1dc833299c51a9930a76849)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
