### PR TITLE
fix(browser): gate rust-native fields behind browser-native feature

### DIFF
--- a/src/tools/browser.rs
+++ b/src/tools/browser.rs
@@ -63,11 +63,11 @@ pub struct BrowserTool {
     allowed_domains: Vec<String>,
     session_name: Option<String>,
     backend: String,
-    #[allow(dead_code)] // used when browser-native feature is enabled
+    #[cfg(feature = "browser-native")]
     native_headless: bool,
-    #[allow(dead_code)] // used when browser-native feature is enabled
+    #[cfg(feature = "browser-native")]
     native_webdriver_url: String,
-    #[allow(dead_code)] // used when browser-native feature is enabled
+    #[cfg(feature = "browser-native")]
     native_chrome_path: Option<String>,
     computer_use: ComputerUseConfig,
     #[cfg(feature = "browser-native")]
@@ -228,13 +228,19 @@ impl BrowserTool {
         native_chrome_path: Option<String>,
         computer_use: ComputerUseConfig,
     ) -> Self {
+        #[cfg(not(feature = "browser-native"))]
+        let _ = (native_headless, &native_webdriver_url, &native_chrome_path);
+
         Self {
             security,
             allowed_domains: normalize_domains(allowed_domains),
             session_name,
             backend,
+            #[cfg(feature = "browser-native")]
             native_headless,
+            #[cfg(feature = "browser-native")]
             native_webdriver_url,
+            #[cfg(feature = "browser-native")]
             native_chrome_path,
             computer_use,
             #[cfg(feature = "browser-native")]
@@ -1988,7 +1994,7 @@ fn unavailable_action_for_backend_error(action: &str, backend: ResolvedBackend) 
     )
 }
 
-#[allow(dead_code)] // used when browser-native feature is enabled
+#[cfg(any(feature = "browser-native", test))]
 fn is_recoverable_rust_native_error(err: &anyhow::Error) -> bool {
     let message = format!("{err:#}").to_ascii_lowercase();
 


### PR DESCRIPTION
### Motivation
- Prevent broad `#[allow(dead_code)]` usage for rust-native browser members by compiling native-only fields only when the `browser-native` feature is enabled.
- Preserve the existing public constructor API and test coverage while eliminating unused-variable noise when the feature is disabled.

### Description
- Gate `BrowserTool` rust-native-only fields (`native_headless`, `native_webdriver_url`, `native_chrome_path`) with `#[cfg(feature = "browser-native")]` so they are only compiled when the feature is enabled (`src/tools/browser.rs`).
- Keep `new_with_backend(...)` API unchanged and add a `#[cfg(not(feature = "browser-native"))] let _ = (...)` sink to consume native-related parameters when the feature is disabled and avoid unused-variable warnings.
- Replace the broad `#[allow(dead_code)]` on `is_recoverable_rust_native_error` with a tighter compile gate `#[cfg(any(feature = "browser-native", test))]` so the helper is available for native builds and tests only.

### Testing
- Ran `cargo fmt --all -- --check` which failed due to unrelated formatting drift in `src/agent/tests.rs` (pre-existing, not introduced by this patch).
- Ran `cargo clippy --all-targets -- -D warnings` which failed due to many existing dead-code/unused warnings across the repository; failures are repo-wide and unrelated to the browser gating change.
- Started `cargo test`; the build and test run proceeded but did not complete within the available execution window (compilation produced many warnings); no test failures attributable to this change were observed before the run timed out.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03bc1e6088332975934146e53e975)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
