### PR TITLE
fix(gateway): narrow dead_code allow on GatewayMessage::Error

### DIFF
--- a/src/gateway/nodes.rs
+++ b/src/gateway/nodes.rs
@@ -166,15 +166,13 @@ enum NodeMessage {
 /// Messages sent to a node.
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-#[allow(dead_code)] // variants used in serialization and tests
 enum GatewayMessage {
     Registered {
         node_id: String,
         capabilities_count: usize,
     },
-    Error {
-        message: String,
-    },
+    #[allow(dead_code)] // protocol message variant kept for serialized gateway errors
+    Error { message: String },
     Invoke {
         call_id: String,
         capability: String,


### PR DESCRIPTION
### Motivation
- The enum-wide `#[allow(dead_code)]` was silencing lints for all `GatewayMessage` variants, but only the `Error` variant is legitimately unused in Rust code while required by the wire-format, so lint scope should be narrowed.

### Description
- Removed the enum-level `#[allow(dead_code)]` and added `#[allow(dead_code)]` only to the `GatewayMessage::Error` variant, preserving the `#[serde(tag = "type", rename_all = "snake_case")]` serialization contract and converting the `Error` variant to a compact single-line declaration.

### Testing
- Ran `cargo fmt --all -- --check`, which failed due to a pre-existing formatting issue in `src/agent/tests.rs` unrelated to this change.
- Ran `cargo clippy --all-targets -- -D warnings`, which could not complete cleanly due to repository-wide unused/dead-code lints and environment build contention.
- Attempted `cargo test --lib gateway::nodes`, but the run was blocked/impeded by existing build processes in the environment and could not complete; this change is a low-risk lint-scope adjustment only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03bde6420833286f68958ef0dd447)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
