### PR TITLE
fix(serde): annotate and document deserialized-but-unused fields

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -82,6 +82,9 @@ struct TimelineEvent {
     #[serde(rename = "type")]
     event_type: String,
     sender: String,
+    // Deserialized from Matrix timeline payloads for correlation/debugging.
+    // Some call paths only need body/msgtype and intentionally ignore event_id.
+    #[allow(dead_code)]
     #[serde(default)]
     event_id: Option<String>,
     #[serde(default)]

--- a/src/channels/qq.rs
+++ b/src/channels/qq.rs
@@ -65,6 +65,7 @@ enum QQSendSegment {
 #[derive(Debug, Deserialize)]
 struct QQUploadResponse {
     file_info: String,
+    // Returned by QQ upload API; stored for forward-compat/debug use.
     #[allow(dead_code)]
     file_uuid: Option<String>,
     ttl: Option<u64>,

--- a/src/config/schema/mod.rs
+++ b/src/config/schema/mod.rs
@@ -2624,6 +2624,9 @@ pub struct KnowledgeConfig {
     #[serde(default)]
     pub enabled: bool,
     /// Path to the knowledge graph SQLite database.
+    /// This may be populated during deserialization for diagnostics even when
+    /// a given code path does not read it directly.
+    #[allow(dead_code)]
     #[serde(default = "default_knowledge_db_path")]
     pub db_path: String,
     /// Maximum number of knowledge nodes. Default: 100000.

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -258,6 +258,8 @@ struct ConverseRequest {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct ConverseMessage {
+    // Present in both request/response shapes; retained for serde compatibility.
+    #[allow(dead_code)]
     role: String,
     content: Vec<ContentBlock>,
 }
@@ -401,6 +403,7 @@ struct ConverseResponse {
     #[serde(default)]
     output: Option<ConverseOutput>,
     #[serde(default)]
+    // Useful for diagnostics even when normal flow only reads `output`.
     #[allow(dead_code)]
     stop_reason: Option<String>,
     #[serde(default)]
@@ -424,6 +427,7 @@ struct ConverseOutput {
 
 #[derive(Debug, Deserialize)]
 struct ConverseOutputMessage {
+    // Included in Bedrock output envelope even when callers only consume text/tool blocks.
     #[allow(dead_code)]
     role: String,
     content: Vec<ResponseContentBlock>,


### PR DESCRIPTION
### Motivation
- Some struct fields are present only to satisfy serde deserialization of upstream/json envelopes and are not read on every code path, but should be retained for compatibility, debugging, or future use.
- Marking these fields as intentionally unused avoids reviewer confusion and documents the runtime contract without changing behavior.

### Description
- Added `#[allow(dead_code)]` and explanatory comments to clarify intent for deserialization-only fields in multiple modules.
- Changes touch the following serde types: `TimelineEvent.event_id` in `src/channels/matrix.rs`, `QQUploadResponse.file_uuid` in `src/channels/qq.rs`, `ConverseMessage.role`, `ConverseResponse.stop_reason`, and `ConverseOutputMessage.role` in `src/providers/bedrock.rs`, and `KnowledgeConfig.db_path` in `src/config/schema/mod.rs`.
- These edits are comment/attribute-only and do not modify runtime logic or serialization formats.

### Testing
- Ran `cargo fmt --all -- --check` which failed due to a pre-existing formatting diff in `src/agent/tests.rs` unrelated to this patch. (Formatting mismatch reported; patch did not change that file.)
- Ran `cargo clippy --all-targets -- -D warnings` which failed because the repository already contains broad `dead_code`/unused warnings unrelated to these targeted annotations; this PR does not introduce new warnings.
- Started `cargo test`; build proceeded and compiled many crates but full test execution was not completed within the interactive session due to long build/test time. The changes are low-risk, compile-time attribute additions with no behavior changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c03b9ec0488332b64c900c694ca650)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
