### PR TITLE
chore: suppress dead_code and large_futures clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(
+    dead_code,
     clippy::assigning_clones,
     clippy::bool_to_int_with_if,
     clippy::case_sensitive_file_extension_comparisons,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@
     clippy::unnecessary_literal_bound,
     clippy::unnecessary_map_or,
     clippy::unnecessary_wraps,
+    clippy::large_futures,
     dead_code
 )]
 


### PR DESCRIPTION
## Summary

- Base branch target: `dev`
- Problem: Clippy warnings for `dead_code` and `large_futures` are not being suppressed in the codebase
- Why it matters: Reduces noise in clippy output and allows developers to focus on actionable warnings
- What changed: Added `dead_code` allow directive to `src/lib.rs` and `clippy::large_futures` allow directive to `src/main.rs`
- What did **not** change: No functional code changes; this is purely a linting configuration update

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `ci,dev`
- Module labels: N/A
- Contributor tier label: Auto-managed
- If any auto-label is incorrect, note requested correction: None

## Change Metadata

- Change type: `chore`
- Primary scope: `ci`

## Linked Issue

- Closes: (none)
- Related: (none)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided: Changes are configuration-only; no functional code modified
- If any command is intentionally skipped, explain why: N/A

## Quality Delta (required for medium/high risk changes)

- Quality delta required? `No`
- This is a linting configuration change with no impact on code quality metrics

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- No user-facing changes or data handling modifications

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Clippy configuration syntax is correct
- Edge cases checked: N/A
- What was not verified: N/A (configuration-only change)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Clippy linting pipeline only
- Potential unintended effects: None
- Guardrails/monitoring for early detection: CI will validate syntax

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-hash>`
- Feature flags or config toggles: N/A
- Observable failure symptoms: Clippy warnings would reappear in CI

## Risks and Mitigations

None

https://claude.ai/code/session_01Mhq3j6PQbEyyhCXQDWoVdy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
