### PR TITLE
fix(ci): handle website redeploy auth failures in release workflows

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -292,11 +292,33 @@ jobs:
         env:
           PAT: ${{ secrets.WEBSITE_REPO_PAT }}
         run: |
-          curl -fsSL -X POST \
-            -H "Authorization: token $PAT" \
+          if [ -z "$PAT" ]; then
+            echo "::warning::WEBSITE_REPO_PAT is not configured; skipping website redeploy dispatch"
+            exit 0
+          fi
+
+          response_file=$(mktemp)
+          status=$(curl -sSL -o "$response_file" -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $PAT" \
             -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/R.A.I.N.-labs/R.A.I.N.-website/dispatches \
-            -d '{"event_type":"new-release","client_payload":{"install_script_url":"https://raw.githubusercontent.com/R.A.I.N.-labs/R.A.I.N./main/install.sh"}}'
+            -d '{"event_type":"new-release","client_payload":{"install_script_url":"https://raw.githubusercontent.com/R.A.I.N.-labs/R.A.I.N./main/install.sh"}}')
+
+          if [ "$status" = "204" ]; then
+            echo "Website redeploy dispatch accepted"
+            exit 0
+          fi
+
+          if [ "$status" = "401" ] || [ "$status" = "403" ]; then
+            echo "::warning::Website redeploy skipped: WEBSITE_REPO_PAT is missing repository_dispatch access or is unauthorized (HTTP $status)"
+            cat "$response_file"
+            exit 0
+          fi
+
+          echo "::error::Website redeploy dispatch failed with HTTP $status"
+          cat "$response_file"
+          exit 1
 
   docker:
     name: Push Docker Image

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -363,11 +363,33 @@ jobs:
         env:
           PAT: ${{ secrets.WEBSITE_REPO_PAT }}
         run: |
-          curl -fsSL -X POST \
-            -H "Authorization: token $PAT" \
+          if [ -z "$PAT" ]; then
+            echo "::warning::WEBSITE_REPO_PAT is not configured; skipping website redeploy dispatch"
+            exit 0
+          fi
+
+          response_file=$(mktemp)
+          status=$(curl -sSL -o "$response_file" -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer $PAT" \
             -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/R.A.I.N.-labs/R.A.I.N.-website/dispatches \
-            -d '{"event_type":"new-release","client_payload":{"install_script_url":"https://raw.githubusercontent.com/R.A.I.N.-labs/R.A.I.N./main/install.sh"}}'
+            -d '{"event_type":"new-release","client_payload":{"install_script_url":"https://raw.githubusercontent.com/R.A.I.N.-labs/R.A.I.N./main/install.sh"}}')
+
+          if [ "$status" = "204" ]; then
+            echo "Website redeploy dispatch accepted"
+            exit 0
+          fi
+
+          if [ "$status" = "401" ] || [ "$status" = "403" ]; then
+            echo "::warning::Website redeploy skipped: WEBSITE_REPO_PAT is missing repository_dispatch access or is unauthorized (HTTP $status)"
+            cat "$response_file"
+            exit 0
+          fi
+
+          echo "::error::Website redeploy dispatch failed with HTTP $status"
+          cat "$response_file"
+          exit 1
 
   docker:
     name: Push Docker Image


### PR DESCRIPTION
### Motivation
- The release workflows can be blocked by a failing cross-repo website dispatch when `WEBSITE_REPO_PAT` is missing or unauthorized, producing opaque `curl: (22)` errors.
- The redeploy step should not fail release publication for downstream auth drift, and should surface clearer diagnostics when dispatches fail.

### Description
- Harden the website redeploy step in `.github/workflows/release-stable-manual.yml` to short-circuit when `WEBSITE_REPO_PAT` is empty, use a Bearer `Authorization` header, include the `X-GitHub-Api-Version` header, capture the HTTP status/body, treat `204` as success, downgrade `401`/`403` to warnings, and fail on other non-success statuses.
- Apply the same changes to the beta release workflow at `.github/workflows/release-beta-on-push.yml` so both release paths behave consistently.
- The redeploy step now writes the dispatch response to a temporary file for diagnostics and emits explicit success/warning/error messages.

### Testing
- Ran `cargo fmt --all -- --check` and it passed successfully.
- Ran `cargo clippy --all-targets -- -D warnings` and it passed (no new lints introduced by the workflow-only change).
- Ran `cargo test`, which reproduced pre-existing failing tests (5 failing tests related to 403 Forbidden responses) that are unrelated to this workflow change.
- Verified workflow file sanity (tab check script) and inspected diffs for the two modified workflow files; `actionlint` was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c14b3c61688324aecbcee367eb29e8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
