### PR TITLE
feat(agent): scaffold manifest-driven identity and blackboard lab orchestrator

### DIFF
--- a/james_library/launcher/swarm_orchestrator.py
+++ b/james_library/launcher/swarm_orchestrator.py
@@ -21,6 +21,11 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11 fallback
+    tomllib = None
+
 
 # ---------------------------------------------------------------------------
 # 1. Reviewer Persona Generator
@@ -240,6 +245,143 @@ class SwarmTranscript:
     started_at: str = ""
     finished_at: str = ""
     total_duration_s: float = 0.0
+
+
+@dataclass
+class AgentToolScope:
+    """Manifest-defined tool access scopes for one specialist."""
+
+    allowed: list[str] = field(default_factory=list)
+
+
+@dataclass
+class AgentMemoryRouting:
+    """Manifest-defined memory and RAG routing hints."""
+
+    categories: list[str] = field(default_factory=list)
+    session_id: str | None = None
+
+
+@dataclass
+class AgentIdentity:
+    """Strict agent identity contract sourced from manifest."""
+
+    agent_id: str
+    display_name: str
+    role: str
+    system_prompt: str
+
+
+@dataclass
+class AgentManifest:
+    """Schema-first manifest replacing loose *_SOUL.md files."""
+
+    schema_version: str
+    identity: AgentIdentity
+    tools: AgentToolScope = field(default_factory=AgentToolScope)
+    memory: AgentMemoryRouting = field(default_factory=AgentMemoryRouting)
+
+
+def load_agent_manifest(manifest_path: str | Path) -> AgentManifest:
+    """Load a strict TOML agent manifest from disk."""
+    path = Path(manifest_path)
+    if tomllib is None:
+        raise RuntimeError("tomllib unavailable; Python 3.11+ required for TOML manifests")
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+
+    identity = raw.get("identity", {})
+    return AgentManifest(
+        schema_version=str(raw.get("schema_version", "")),
+        identity=AgentIdentity(
+            agent_id=str(identity.get("id", "")),
+            display_name=str(identity.get("display_name", "")),
+            role=str(identity.get("role", "")),
+            system_prompt=str(identity.get("system_prompt", "")),
+        ),
+        tools=AgentToolScope(allowed=list(raw.get("tools", {}).get("allowed", []))),
+        memory=AgentMemoryRouting(
+            categories=list(raw.get("memory", {}).get("categories", [])),
+            session_id=raw.get("memory", {}).get("session_id"),
+        ),
+    )
+
+
+async def run_blackboard_lab(
+    query: str,
+    manifests: list[AgentManifest],
+    config: SwarmConfig | None = None,
+) -> dict[str, Any]:
+    """Prototype blackboard orchestrator for multi-specialist collaboration.
+
+    Each specialist receives the same shared room context plus a role-specific
+    sub-task. The output is synthesized into a single response envelope.
+    """
+    cfg = config or SwarmConfig(rounds=1, temperature=0.3, max_tokens_per_turn=384)
+    model = cfg.model_name or os.environ.get("LM_STUDIO_MODEL", "qwen2.5-coder-7b-instruct")
+    base_url = cfg.base_url or os.environ.get("LM_STUDIO_BASE_URL", "http://localhost:1234/v1")
+    api_key = cfg.api_key or os.environ.get("LM_STUDIO_API_KEY", "not-needed")
+
+    try:
+        import openai as _openai
+    except ImportError as exc:
+        raise RuntimeError("openai package required for lab orchestration: pip install openai") from exc
+
+    try:
+        import httpx
+        timeout = httpx.Timeout(min(15.0, cfg.timeout), read=cfg.timeout, write=15.0, connect=15.0)
+        client = _openai.OpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
+    except ImportError:
+        client = _openai.OpenAI(base_url=base_url, api_key=api_key)
+
+    room_context = (
+        "You are operating in a shared lab blackboard. "
+        "Read peer notes and contribute only your specialist perspective."
+    )
+    per_agent_notes: list[dict[str, str]] = []
+
+    for manifest in manifests:
+        memory_hint = ", ".join(manifest.memory.categories) if manifest.memory.categories else "default"
+        tool_hint = ", ".join(manifest.tools.allowed) if manifest.tools.allowed else "none"
+        user_message = (
+            f"{room_context}\n\n"
+            f"User query: {query}\n"
+            f"Your role: {manifest.identity.role}\n"
+            f"Allowed tools: {tool_hint}\n"
+            f"Memory routes: {memory_hint}\n\n"
+            f"Provide findings, assumptions, and one recommended next step."
+        )
+        response = await _call_llm_async(
+            client=client,
+            model=model,
+            system_prompt=manifest.identity.system_prompt,
+            user_message=user_message,
+            temperature=cfg.temperature,
+            max_tokens=cfg.max_tokens_per_turn,
+        )
+        per_agent_notes.append(
+            {
+                "agent_id": manifest.identity.agent_id,
+                "agent_name": manifest.identity.display_name,
+                "role": manifest.identity.role,
+                "notes": response,
+            }
+        )
+
+    synthesis_prompt = (
+        "You are the lab chair. Synthesize specialist notes into one integrated answer.\n\n"
+        f"User query: {query}\n\n"
+        f"Specialist notes:\n{json.dumps(per_agent_notes, ensure_ascii=False, indent=2)}"
+    )
+    synthesis = await _call_llm_async(
+        client=client,
+        model=model,
+        system_prompt="Synthesize into a concise multi-perspective answer with clear action items.",
+        user_message=synthesis_prompt,
+        temperature=0.2,
+        max_tokens=768,
+    )
+
+    return {"query": query, "specialist_notes": per_agent_notes, "synthesized_response": synthesis}
 
 
 async def _call_llm_async(

--- a/james_library/launcher/swarm_orchestrator.py
+++ b/james_library/launcher/swarm_orchestrator.py
@@ -335,15 +335,23 @@ async def run_blackboard_lab(
 
     room_context = (
         "You are operating in a shared lab blackboard. "
-        "Read peer notes and contribute only your specialist perspective."
+        "Review any prior peer notes and contribute only your specialist perspective."
     )
     per_agent_notes: list[dict[str, str]] = []
 
     for manifest in manifests:
         memory_hint = ", ".join(manifest.memory.categories) if manifest.memory.categories else "default"
         tool_hint = ", ".join(manifest.tools.allowed) if manifest.tools.allowed else "none"
+        if per_agent_notes:
+            peer_section = (
+                f"Peer notes so far:\n"
+                f"{json.dumps(per_agent_notes, ensure_ascii=False, indent=2)}\n\n"
+            )
+        else:
+            peer_section = "No peer notes yet — you are the first specialist.\n\n"
         user_message = (
             f"{room_context}\n\n"
+            f"{peer_section}"
             f"User query: {query}\n"
             f"Your role: {manifest.identity.role}\n"
             f"Allowed tools: {tool_hint}\n"

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -13,8 +13,10 @@ use crate::runtime;
 use crate::security::SecurityPolicy;
 use crate::tools::{self, Tool, ToolSpec};
 use anyhow::Result;
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::Write as IoWrite;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -47,6 +49,49 @@ pub struct Agent {
     security_summary: Option<String>,
     /// Autonomy level from config; controls safety prompt instructions.
     autonomy_level: crate::security::AutonomyLevel,
+    manifest: Option<AgentManifest>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AgentManifest {
+    pub schema_version: String,
+    pub identity: AgentIdentityManifest,
+    #[serde(default)]
+    pub tools: AgentToolScopeManifest,
+    #[serde(default)]
+    pub memory: AgentMemoryRoutingManifest,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct AgentIdentityManifest {
+    pub id: String,
+    pub display_name: String,
+    pub role: String,
+    pub system_prompt: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentToolScopeManifest {
+    #[serde(default)]
+    pub allowed: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
+pub struct AgentMemoryRoutingManifest {
+    #[serde(default)]
+    pub categories: Vec<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+}
+
+fn load_agent_manifest(workspace_dir: &Path) -> Result<Option<AgentManifest>> {
+    let manifest_path = workspace_dir.join("agent_manifest.toml");
+    if !manifest_path.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(&manifest_path)?;
+    let manifest: AgentManifest = toml::from_str(&raw)?;
+    Ok(Some(manifest))
 }
 
 pub struct AgentBuilder {
@@ -289,6 +334,7 @@ impl AgentBuilder {
             autonomy_level: self
                 .autonomy_level
                 .unwrap_or(crate::security::AutonomyLevel::Supervised),
+            manifest: None,
         })
     }
 }
@@ -374,6 +420,19 @@ impl Agent {
             config,
             ModelSwitchState::default(),
         );
+
+        let manifest = load_agent_manifest(&config.workspace_dir)?;
+        if let Some(agent_manifest) = manifest.as_ref() {
+            if !agent_manifest.tools.allowed.is_empty() {
+                tools.retain(|tool| {
+                    agent_manifest
+                        .tools
+                        .allowed
+                        .iter()
+                        .any(|allowed| allowed == tool.name())
+                });
+            }
+        }
 
         // ── Wire MCP tools (non-fatal) ─────────────────────────────
         // Replicates the same MCP initialization logic used in the CLI
@@ -483,7 +542,7 @@ impl Agent {
             None
         };
 
-        Agent::builder()
+        let mut agent = Agent::builder()
             .provider(provider)
             .tools(tools)
             .memory(memory)
@@ -511,7 +570,14 @@ impl Agent {
             .auto_save(config.memory.auto_save)
             .security_summary(Some(security.prompt_summary()))
             .autonomy_level(config.autonomy.level)
-            .build()
+            .build()?;
+
+        if let Some(agent_manifest) = manifest {
+            agent.memory_session_id = agent_manifest.memory.session_id.clone();
+            agent.manifest = Some(agent_manifest);
+        }
+
+        Ok(agent)
     }
 
     fn trim_history(&mut self) {
@@ -555,7 +621,18 @@ impl Agent {
             security_summary: self.security_summary.clone(),
             autonomy_level: self.autonomy_level,
         };
-        self.prompt_builder.build(&ctx)
+        let mut prompt = self.prompt_builder.build(&ctx)?;
+        if let Some(manifest) = self.manifest.as_ref() {
+            prompt.push_str("\n\n## Agent Manifest Identity\n\n");
+            prompt.push_str(&format!(
+                "- Agent: {} ({})\n- Role: {}\n\n{}",
+                manifest.identity.display_name,
+                manifest.identity.id,
+                manifest.identity.role,
+                manifest.identity.system_prompt
+            ));
+        }
+        Ok(prompt)
     }
 
     async fn execute_tool_call(&self, call: &ParsedToolCall) -> ToolExecutionResult {
@@ -888,6 +965,7 @@ mod tests {
     use async_trait::async_trait;
     use parking_lot::Mutex;
     use std::collections::HashMap;
+    use tempfile::tempdir;
 
     struct MockProvider {
         responses: Mutex<Vec<crate::providers::ChatResponse>>,
@@ -1322,5 +1400,40 @@ mod tests {
             matches!(&history[2], ConversationMessage::Chat(m) if m.role == "assistant" && m.content == "hi there")
         );
         assert_eq!(history.len(), 3);
+    }
+
+    #[test]
+    fn load_agent_manifest_reads_toml_schema() {
+        let dir = tempdir().expect("tempdir should be created");
+        let manifest = r#"
+schema_version = "1.0"
+
+[identity]
+id = "james"
+display_name = "James"
+role = "Lead Scientist"
+system_prompt = "Focus on resonance."
+
+[tools]
+allowed = ["file_read", "web_search"]
+
+[memory]
+categories = ["research", "notes"]
+session_id = "lab-session"
+"#;
+        std::fs::write(dir.path().join("agent_manifest.toml"), manifest)
+            .expect("manifest should be written");
+
+        let parsed = load_agent_manifest(dir.path())
+            .expect("manifest should parse")
+            .expect("manifest should exist");
+
+        assert_eq!(parsed.identity.id, "james");
+        assert_eq!(parsed.tools.allowed, vec!["file_read", "web_search"]);
+        assert_eq!(
+            parsed.memory.categories,
+            vec!["research".to_string(), "notes".to_string()]
+        );
+        assert_eq!(parsed.memory.session_id.as_deref(), Some("lab-session"));
     }
 }

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -422,17 +422,6 @@ impl Agent {
         );
 
         let manifest = load_agent_manifest(&config.workspace_dir)?;
-        if let Some(agent_manifest) = manifest.as_ref() {
-            if !agent_manifest.tools.allowed.is_empty() {
-                tools.retain(|tool| {
-                    agent_manifest
-                        .tools
-                        .allowed
-                        .iter()
-                        .any(|allowed| allowed == tool.name())
-                });
-            }
-        }
 
         // ── Wire MCP tools (non-fatal) ─────────────────────────────
         // Replicates the same MCP initialization logic used in the CLI
@@ -491,6 +480,19 @@ impl Agent {
                 Err(e) => {
                     tracing::error!("MCP registry failed to initialize: {e:#}");
                 }
+            }
+        }
+
+        // ── Apply manifest tool allowlist (after all tools are registered) ──
+        if let Some(agent_manifest) = manifest.as_ref() {
+            if !agent_manifest.tools.allowed.is_empty() {
+                tools.retain(|tool| {
+                    agent_manifest
+                        .tools
+                        .allowed
+                        .iter()
+                        .any(|allowed| allowed == tool.name())
+                });
             }
         }
 


### PR DESCRIPTION
### Motivation

- Introduce a strict, schema-first contract for specialist agents to replace loose SOUL/markdown identity files to make agent identity, tool scopes, and memory routing explicit and machine-readable.
- Allow per-agent tool scoping and memory routing at agent creation time so specialist agents can be sandboxed to a defined capability set and RAG routing behavior.
- Provide a first-stage orchestrator that moves orchestration from linear peer-review swarms toward a shared blackboard/room model for multi-specialist synthesis.

### Description

- Added a Rust `AgentManifest` schema and TOML loader in `src/agent/agent.rs` with `identity`, `tools.allowed`, and `memory.{categories,session_id}` fields and a `load_agent_manifest` helper to read `agent_manifest.toml` from the workspace root.
- Wired manifest support into `Agent::from_config` to optionally filter the tool registry by the manifest `tools.allowed` list and to set the agent `memory_session_id` and retain the parsed `manifest` on the agent for prompt injection.
- Injected manifest identity/system-prompt content into the agent system prompt via `build_system_prompt` so LLMs see the concrete specialist identity during runtime.
- Added Python-side dataclasses and a TOML manifest loader plus a prototype `run_blackboard_lab(...)` in `james_library/launcher/swarm_orchestrator.py` that fans out the user query to each manifested specialist, collects notes, and synthesizes a single integrated response.

### Testing

- Ran `cargo fmt --all -- --check` which succeeded and `cargo fmt --all` to normalize formatting.
- Executed `python -m pytest -q tests/test_lab_orchestrator.py` which passed (`4 passed`).
- Added a focused Rust unit test `load_agent_manifest_reads_toml_schema` covering TOML manifest parsing which is included in the change set.
- Attempted broader workspace checks (`cargo clippy --all-targets -- -D warnings` and `cargo test`) but the full-workspace Rust compile/lint runs were long-running in this environment and were interrupted; recommend running them in CI or a local environment with full toolchain available before merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c22c5dd430832488fdcf92e2236d9b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
