### PR TITLE
feat(launcher): add lab blackboard orchestration flow

### DIFF
--- a/james_library/launcher/swarm_orchestrator.py
+++ b/james_library/launcher/swarm_orchestrator.py
@@ -242,6 +242,270 @@ class SwarmTranscript:
     total_duration_s: float = 0.0
 
 
+@dataclass(frozen=True)
+class AgentManifestRef:
+    """Reference to an on-disk manifest that produced a LabAgent."""
+
+    path: str
+    manifest_id: str
+
+
+@dataclass
+class LabAgent:
+    """Runtime representation of one specialist available to the lab."""
+
+    agent_id: str
+    name: str
+    system_prompt: str
+    capability_tags: set[str] = field(default_factory=set)
+    tool_scopes: set[str] = field(default_factory=set)
+    domain_hints: set[str] = field(default_factory=set)
+    manifest_ref: AgentManifestRef | None = None
+
+
+@dataclass
+class BlackboardEntry:
+    """Normalized per-agent contribution for one delegated subtask."""
+
+    task_id: str
+    agent_id: str
+    output: str
+    confidence: float
+    rationale: str = ""
+    conflict_notes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class LabRoomConfig:
+    """Tuning parameters for lab-mode orchestration."""
+
+    max_subtasks: int = 4
+    max_agents_per_task: int = 2
+    temperature: float = 0.3
+    max_tokens_per_turn: int = 512
+    model_name: str = ""
+    base_url: str = ""
+    api_key: str = "not-needed"
+    timeout: float = 120.0
+
+
+@dataclass(frozen=True)
+class DelegationTask:
+    """Subtask emitted by planner and delegated to specialist agents."""
+
+    task_id: str
+    description: str
+    required_tags: tuple[str, ...] = ()
+    domain_hint: str = ""
+    tool_scope: str = ""
+    reason: str = ""
+
+
+def load_lab_roster(manifest_paths: list[str | Path]) -> list[LabAgent]:
+    """Load agent manifests and normalize capability/tool/domain metadata."""
+    roster: list[LabAgent] = []
+    for raw_path in manifest_paths:
+        path = Path(raw_path)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        manifest_id = str(payload.get("id") or payload.get("agent_id") or path.stem)
+        manifest_ref = AgentManifestRef(path=str(path), manifest_id=manifest_id)
+
+        capability_tags = set(payload.get("capability_tags") or payload.get("capabilities") or [])
+        tool_scopes = set(payload.get("tool_scopes") or payload.get("tools") or [])
+        domain_hints = set(payload.get("domain_hints") or payload.get("domains") or [])
+        if "domain" in payload:
+            domain_hints.add(str(payload["domain"]))
+
+        roster.append(
+            LabAgent(
+                agent_id=manifest_id,
+                name=str(payload.get("name") or manifest_id),
+                system_prompt=str(payload.get("system_prompt") or payload.get("prompt") or ""),
+                capability_tags={str(v).lower() for v in capability_tags},
+                tool_scopes={str(v).lower() for v in tool_scopes},
+                domain_hints={str(v).lower() for v in domain_hints},
+                manifest_ref=manifest_ref,
+            )
+        )
+    return roster
+
+
+def _query_tags(query: str) -> set[str]:
+    tokens = {w.strip(" ,.:;!?()[]{}").lower() for w in query.split()}
+    return {t for t in tokens if t}
+
+
+def plan_subtasks(query: str, roster: list[LabAgent], max_subtasks: int = 4) -> list[DelegationTask]:
+    """Create deterministic specialist subtasks based on query + roster."""
+    tags = _query_tags(query)
+    domain = _detect_domain(query)
+    all_capabilities = sorted({cap for a in roster for cap in a.capability_tags})
+
+    selected_caps: list[str] = []
+    for cap in all_capabilities:
+        if cap in tags:
+            selected_caps.append(cap)
+    if not selected_caps:
+        selected_caps = all_capabilities[:max_subtasks]
+
+    tasks: list[DelegationTask] = [
+        DelegationTask(
+            task_id=f"task_{idx + 1:02d}",
+            description=f"Assess query from {cap} perspective.",
+            required_tags=(cap,),
+            domain_hint=domain,
+            reason=f"Matched capability tag '{cap}' from query.",
+        )
+        for idx, cap in enumerate(selected_caps[:max_subtasks])
+    ]
+    if not tasks:
+        tasks.append(
+            DelegationTask(
+                task_id="task_01",
+                description="Provide methodological critique and concrete answer.",
+                domain_hint=domain,
+                reason="Fallback task when no capability tags are available.",
+            )
+        )
+    return tasks
+
+
+def _select_agents_for_task(task: DelegationTask, roster: list[LabAgent], max_agents: int) -> list[LabAgent]:
+    ranked: list[tuple[int, str, LabAgent]] = []
+    required = set(task.required_tags)
+    for agent in roster:
+        score = 0
+        score += 5 * len(required & agent.capability_tags)
+        if task.domain_hint and task.domain_hint in agent.domain_hints:
+            score += 3
+        if task.tool_scope and task.tool_scope in agent.tool_scopes:
+            score += 2
+        ranked.append((score, agent.agent_id, agent))
+    ranked.sort(key=lambda item: (-item[0], item[1]))
+    selected = [agent for score, _, agent in ranked if score > 0][:max_agents]
+    if not selected:
+        selected = [agent for _, _, agent in ranked[:max_agents]]
+    return selected
+
+
+def post_to_blackboard(blackboard: dict[str, Any], entry: BlackboardEntry) -> None:
+    outputs: list[BlackboardEntry] = blackboard.setdefault("agent_outputs", [])
+    outputs.append(entry)
+    outputs.sort(key=lambda item: (item.task_id, item.agent_id))
+
+
+def _detect_conflicts(outputs: list[BlackboardEntry]) -> list[str]:
+    by_task: dict[str, list[BlackboardEntry]] = {}
+    for output in outputs:
+        by_task.setdefault(output.task_id, []).append(output)
+
+    conflict_notes: list[str] = []
+    negative_terms = ("reject", "unsafe", "invalid", "fail", "cannot", "not")
+    positive_terms = ("valid", "safe", "correct", "supports", "works", "can")
+    for task_id, entries in sorted(by_task.items()):
+        has_neg = any(any(t in e.output.lower() for t in negative_terms) for e in entries)
+        has_pos = any(any(t in e.output.lower() for t in positive_terms) for e in entries)
+        if has_neg and has_pos:
+            conflict_notes.append(f"{task_id}: conflicting polarity across agent conclusions.")
+    return conflict_notes
+
+
+def synthesize_lab_answer(blackboard: dict[str, Any]) -> str:
+    """Merge blackboard artifacts into a single sectioned response."""
+    outputs: list[BlackboardEntry] = list(blackboard.get("agent_outputs", []))
+    outputs.sort(key=lambda item: (item.task_id, item.agent_id))
+    conflicts = _detect_conflicts(outputs)
+
+    sections: list[str] = ["## Lab Answer"]
+    for entry in outputs:
+        sections.append(
+            f"### {entry.task_id} · {entry.agent_id}\n"
+            f"- Confidence: {entry.confidence:.2f}\n"
+            f"- Output: {entry.output}\n"
+            f"- Rationale: {entry.rationale or 'n/a'}"
+        )
+
+    sections.append("## Conflict Notes")
+    if conflicts:
+        sections.extend([f"- {note}" for note in conflicts])
+    else:
+        sections.append("- No material conflicts detected.")
+
+    blackboard["consensus"] = "conflicted" if conflicts else "aligned"
+    blackboard["conflicts"] = conflicts
+    return "\n\n".join(sections)
+
+
+async def dispatch_subtasks(
+    query: str,
+    tasks: list[DelegationTask],
+    roster: list[LabAgent],
+    *,
+    cfg: LabRoomConfig | None = None,
+    runner: Any | None = None,
+) -> list[BlackboardEntry]:
+    """Fan out subtasks across selected agents concurrently."""
+    room_cfg = cfg or LabRoomConfig()
+    invoke = runner or _run_lab_agent
+    coros: list[asyncio.Future[Any] | Any] = []
+    for task in tasks:
+        agents = _select_agents_for_task(task, roster, room_cfg.max_agents_per_task)
+        for agent in agents:
+            coros.append(
+                invoke(
+                    agent=agent,
+                    task=task,
+                    query=query,
+                    cfg=room_cfg,
+                )
+            )
+    results = await asyncio.gather(*coros)
+    results.sort(key=lambda entry: (entry.task_id, entry.agent_id))
+    return results
+
+
+async def _run_lab_agent(agent: LabAgent, task: DelegationTask, query: str, cfg: LabRoomConfig) -> BlackboardEntry:
+    model = cfg.model_name or os.environ.get("LM_STUDIO_MODEL", "qwen2.5-coder-7b-instruct")
+    base_url = cfg.base_url or os.environ.get("LM_STUDIO_BASE_URL", "http://localhost:1234/v1")
+    api_key = cfg.api_key or os.environ.get("LM_STUDIO_API_KEY", "not-needed")
+
+    try:
+        import openai as _openai
+    except ImportError as exc:
+        raise RuntimeError("openai package required for lab orchestration: pip install openai") from exc
+
+    client = _openai.OpenAI(base_url=base_url, api_key=api_key)
+    user_msg = (
+        f"Query: {query}\n"
+        f"Task: {task.description}\n"
+        f"Required tags: {', '.join(task.required_tags) or '(none)'}\n"
+        "Return concise analysis and a confidence score between 0 and 1 at end as `confidence=<value>`."
+    )
+    raw = await _call_llm_async(
+        client=client,
+        model=model,
+        system_prompt=agent.system_prompt or f"You are specialist agent {agent.name}.",
+        user_message=user_msg,
+        temperature=cfg.temperature,
+        max_tokens=cfg.max_tokens_per_turn,
+    )
+    confidence = 0.5
+    for line in raw.splitlines():
+        if "confidence=" in line.lower():
+            try:
+                confidence = float(line.split("=", 1)[1].strip())
+            except ValueError:
+                confidence = 0.5
+            break
+    return BlackboardEntry(
+        task_id=task.task_id,
+        agent_id=agent.agent_id,
+        output=raw,
+        confidence=max(0.0, min(confidence, 1.0)),
+        rationale=task.reason,
+    )
+
+
 async def _call_llm_async(
     client: Any,
     model: str,
@@ -504,7 +768,65 @@ async def synthesize_report(
 
 
 # ---------------------------------------------------------------------------
-# 4. invoke_peer_review - tool-callable entry point
+# 4. Lab session entry points (blackboard orchestration)
+# ---------------------------------------------------------------------------
+
+async def invoke_lab_session(
+    query: str,
+    manifest_paths: list[str | Path],
+    config: LabRoomConfig | None = None,
+) -> dict[str, Any]:
+    """Run one blackboard lab session over a roster loaded from manifests."""
+    cfg = config or LabRoomConfig()
+    roster = load_lab_roster(manifest_paths)
+    subtasks = plan_subtasks(query, roster, max_subtasks=cfg.max_subtasks)
+    blackboard: dict[str, Any] = {
+        "query": query,
+        "subtasks": subtasks,
+        "agent_outputs": [],
+        "consensus": "pending",
+    }
+
+    outputs = await dispatch_subtasks(query=query, tasks=subtasks, roster=roster, cfg=cfg)
+    for entry in outputs:
+        post_to_blackboard(blackboard, entry)
+
+    synthesis = synthesize_lab_answer(blackboard)
+    return {
+        "answer": synthesis,
+        "blackboard": blackboard,
+        "summary": {
+            "agents": len(roster),
+            "subtasks": len(subtasks),
+            "outputs": len(blackboard["agent_outputs"]),
+            "consensus": blackboard["consensus"],
+        },
+    }
+
+
+def invoke_lab_session_sync(
+    query: str,
+    manifest_paths: list[str | Path],
+    config: LabRoomConfig | None = None,
+) -> dict[str, Any]:
+    """Synchronous wrapper for invoke_lab_session."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    coro = invoke_lab_session(query=query, manifest_paths=manifest_paths, config=config)
+    if loop and loop.is_running():
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(asyncio.run, coro)
+            return future.result()
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# 5. invoke_peer_review - tool-callable entry point
 # ---------------------------------------------------------------------------
 
 async def invoke_peer_review(

--- a/tests/test_swarm_orchestrator_lab.py
+++ b/tests/test_swarm_orchestrator_lab.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+from james_library.launcher.swarm_orchestrator import (
+    BlackboardEntry,
+    load_lab_roster,
+    plan_subtasks,
+    post_to_blackboard,
+    synthesize_lab_answer,
+)
+
+
+def test_plan_subtasks_selects_matching_capabilities(tmp_path: Path) -> None:
+    manifest_a = tmp_path / "agent_math.json"
+    manifest_b = tmp_path / "agent_systems.json"
+    manifest_a.write_text(
+        """{
+        "id": "math_agent",
+        "capability_tags": ["statistics", "algebra"],
+        "tool_scopes": ["analysis"],
+        "domain_hints": ["physics"],
+        "system_prompt": "You are a math specialist."
+    }""",
+        encoding="utf-8",
+    )
+    manifest_b.write_text(
+        """{
+        "id": "systems_agent",
+        "capability_tags": ["distributed", "runtime"],
+        "tool_scopes": ["systems"],
+        "domain_hints": ["computer_science"],
+        "system_prompt": "You are a systems specialist."
+    }""",
+        encoding="utf-8",
+    )
+
+    roster = load_lab_roster([manifest_a, manifest_b])
+    tasks = plan_subtasks("Need distributed runtime reliability analysis", roster)
+
+    assert [task.required_tags for task in tasks[:2]] == [("distributed",), ("runtime",)]
+
+
+def test_blackboard_merge_order_and_conflict_detection() -> None:
+    blackboard = {
+        "query": "Is the protocol safe?",
+        "subtasks": [],
+        "agent_outputs": [],
+        "consensus": "pending",
+    }
+
+    # Intentionally post out of order to verify deterministic ordering.
+    post_to_blackboard(
+        blackboard,
+        BlackboardEntry(task_id="task_02", agent_id="agent_b", output="This is valid and safe.", confidence=0.8),
+    )
+    post_to_blackboard(
+        blackboard,
+        BlackboardEntry(task_id="task_01", agent_id="agent_a", output="I reject this as unsafe.", confidence=0.9),
+    )
+    post_to_blackboard(
+        blackboard,
+        BlackboardEntry(task_id="task_02", agent_id="agent_a", output="I reject this as invalid.", confidence=0.7),
+    )
+
+    report = synthesize_lab_answer(blackboard)
+
+    ordered_pairs = [(entry.task_id, entry.agent_id) for entry in blackboard["agent_outputs"]]
+    assert ordered_pairs == [("task_01", "agent_a"), ("task_02", "agent_a"), ("task_02", "agent_b")]
+    assert blackboard["consensus"] == "conflicted"
+    assert "task_02: conflicting polarity across agent conclusions." in report


### PR DESCRIPTION
### Motivation

- Introduce a blackboard-style lab orchestration mode to replace the fixed persona loop with a more extensible specialist roster and delegated subtasks. 
- Enable deterministic agent selection and structured synthesis of multi-agent outputs for clearer rationale and conflict handling. 
- Preserve existing peer-review functionality while adding compatible entry points for lab sessions.

### Description

- Added dataclasses `AgentManifestRef`, `LabAgent`, `BlackboardEntry`, `LabRoomConfig`, and `DelegationTask` to `james_library/launcher/swarm_orchestrator.py` to model manifests, agents, blackboard outputs, room tuning, and subtasks. 
- Implemented `load_lab_roster(manifest_paths)` to read agent manifests and normalize capability tags, tool scopes, and domain hints into `LabAgent` records. 
- Added planning and dispatch primitives: `plan_subtasks(...)` (deterministic task planner), `_select_agents_for_task(...)` (roster-based ranking), `dispatch_subtasks(...)` (async fan-out), and `post_to_blackboard(...)` (deterministic storage & ordering). 
- Implemented `synthesize_lab_answer(blackboard)` that merges per-agent outputs into a sectioned response, detects polarity conflicts, and records consensus state. 
- Preserved existing peer-review entry points and added new `invoke_lab_session` / `invoke_lab_session_sync` entry points for the blackboard flow. 
- Added deterministic unit tests `tests/test_swarm_orchestrator_lab.py` covering roster-based capability selection and blackboard merge ordering plus conflict detection.

### Testing

- Ran linter: `ruff check james_library/launcher/swarm_orchestrator.py tests/test_swarm_orchestrator_lab.py` and it passed. 
- Ran unit tests: `pytest -q tests/test_swarm_orchestrator_lab.py` and the new tests passed (`2 passed`). 
- Ran related smoke tests: `pytest -q tests/test_smoke.py -k swarm_orchestrator` and they passed (`2 passed, 25 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29d266cb883249bdec3579105dcd7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
