### PR TITLE
feat(plugins): add agent pack discovery and trust controls

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -91,6 +91,7 @@ Last refreshed: **February 18, 2026**.
 - [custom-providers.md](contributing/custom-providers.md)
 - [zai-glm-setup.md](setup-guides/zai-glm-setup.md)
 - [langgraph-integration.md](contributing/langgraph-integration.md)
+- [plugin-agent-pack-authoring.md](reference/plugin-agent-pack-authoring.md)
 
 ### 3) Operations & Deployment
 

--- a/docs/config-reference.fr.md
+++ b/docs/config-reference.fr.md
@@ -7,3 +7,8 @@ Schéma de configuration canonique:
 Chargement/fusion de config:
 
 - [`../src/config/mod.rs`](../src/config/mod.rs)
+
+Clés plugin récentes à connaître :
+
+- `[plugins].marketplace_enabled` (désactivé par défaut, requis pour les sources HTTP(S))
+- `[plugins].allowed_permissions` (liste d’autorisations acceptées à l’installation)

--- a/docs/i18n/vi/config-reference.md
+++ b/docs/i18n/vi/config-reference.md
@@ -7,3 +7,8 @@ Schema cấu hình chuẩn:
 Mã tải/gộp cấu hình:
 
 - [`../../../src/config/mod.rs`](../../../src/config/mod.rs)
+
+Các khóa plugin mới:
+
+- `[plugins].marketplace_enabled` (mặc định `false`, bắt buộc để cài từ HTTP(S))
+- `[plugins].allowed_permissions` (allowlist quyền được chấp nhận khi cài plugin)

--- a/docs/i18n/zh-CN/reference/api/config-reference.zh-CN.md
+++ b/docs/i18n/zh-CN/reference/api/config-reference.zh-CN.md
@@ -206,6 +206,23 @@ temperature = 0.2
 - 建议在低上下文本地模型上使用 `prompt_injection_mode = \"compact\"`，以减少启动提示大小，同时按需保留技能文件可用。
 - 技能加载和 `R.A.I.N. skills install` 都会应用静态安全审计。包含符号链接、类脚本文件、高风险 shell  payload 片段或不安全 markdown 链接遍历的技能会被拒绝。
 
+## `[plugins]`
+
+| 键 | 默认值 | 用途 |
+|---|---|---|
+| `enabled` | `false` | 启用 WASM 插件发现和注册 |
+| `plugins_dir` | `~/.R.A.I.N./plugins` | 扫描插件 `manifest.toml` 文件的文件系统路径 |
+| `auto_discover` | `false` | 启动时自动发现插件元数据 |
+| `max_plugins` | `50` | 已加载插件条目的上限 |
+| `marketplace_enabled` | `false` | 允许从远程 `http(s)` 市场源执行 `plugin install` |
+| `allowed_permissions` | `["http_client","file_read","file_write","env_read","memory_read","memory_write"]` | 安装时插件声明权限的允许列表 |
+
+注意事项：
+
+- 远程市场安装默认为故障关闭。需显式设置 `marketplace_enabled = true` 以允许网络插件源。
+- `allowed_permissions` 在安装时强制执行：如果插件请求的权限不在此列表中，安装将被拒绝。
+- 插件元数据可通过 `agent_manifests` 暴露代理包；即使 WASM 执行桥不可用，这些代理包也会被发现。
+
 ## `[composio]`
 
 | 键 | 默认值 | 用途 |

--- a/docs/maintainers/docs-inventory.md
+++ b/docs/maintainers/docs-inventory.md
@@ -53,6 +53,7 @@ Last reviewed: **February 18, 2026**.
 | `docs/custom-providers.md` | Current Integration Guide | integration developers |
 | `docs/zai-glm-setup.md` | Current Provider Setup Guide | users/operators |
 | `docs/langgraph-integration.md` | Current Integration Guide | integration developers |
+| `docs/reference/plugin-agent-pack-authoring.md` | Current Reference | plugin authors |
 | `docs/operations-runbook.md` | Current Guide | operators |
 | `docs/troubleshooting.md` | Current Guide | users/operators |
 | `docs/network-deployment.md` | Current Guide | operators |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -16,6 +16,10 @@ Structured reference index for commands, providers, channels, config, and integr
 - Nextcloud Talk bot integration: [../setup-guides/nextcloud-talk-setup.md](../setup-guides/nextcloud-talk-setup.md)
 - LangGraph-based integration patterns: [../contributing/langgraph-integration.md](../contributing/langgraph-integration.md)
 
+## Plugins
+
+- Plugin agent pack authoring: [plugin-agent-pack-authoring.md](plugin-agent-pack-authoring.md)
+
 ## Usage
 
 Use this collection when you need precise CLI/config details or provider integration patterns rather than step-by-step tutorials.

--- a/docs/reference/api/config-reference.md
+++ b/docs/reference/api/config-reference.md
@@ -196,6 +196,23 @@ Notes:
 - Corrupted/unreadable estop state falls back to fail-closed `kill_all`.
 - Use CLI command `R.A.I.N. estop` to engage and `R.A.I.N. estop resume` to clear levels.
 
+## `[plugins]`
+
+| Key | Default | Purpose |
+|---|---|---|
+| `enabled` | `false` | Enables WASM plugin discovery and registration |
+| `plugins_dir` | `~/.R.A.I.N./plugins` | Filesystem location scanned for plugin `manifest.toml` files |
+| `auto_discover` | `false` | Automatically discover plugin metadata at startup |
+| `max_plugins` | `50` | Upper bound for loaded plugin entries |
+| `marketplace_enabled` | `false` | Allows `plugin install` from remote `http(s)` marketplace sources |
+| `allowed_permissions` | `["http_client","file_read","file_write","env_read","memory_read","memory_write"]` | Install-time allowlist for plugin-declared permissions |
+
+Notes:
+
+- Remote marketplace install is fail-closed by default. Set `marketplace_enabled = true` explicitly to allow network plugin sources.
+- `allowed_permissions` is enforced at install time: if a plugin requests a permission outside this list, installation is rejected.
+- Plugin metadata can expose agent packs via `agent_manifests`; these are discovered even when the WASM execution bridge is unavailable.
+
 ## `[agents.<name>]`
 
 Delegate sub-agent configurations. Each key under `[agents]` defines a named sub-agent that the primary agent can delegate to.

--- a/docs/reference/plugin-agent-pack-authoring.md
+++ b/docs/reference/plugin-agent-pack-authoring.md
@@ -1,0 +1,71 @@
+# Plugin Agent Pack Authoring (WASM Plugins)
+
+This guide defines the required manifest fields and layout for plugin-provided agent packs.
+
+## Plugin layout
+
+Each plugin is discovered from `plugins/<plugin-name>/manifest.toml`.
+
+Recommended layout:
+
+```text
+plugins/
+  example-plugin/
+    manifest.toml
+    plugin.wasm
+    agents/
+      researcher.toml
+      triage.toml
+```
+
+## Required plugin manifest fields
+
+`manifest.toml` must include:
+
+- `name` (string)
+- `version` (string)
+- `wasm_path` (string, relative path)
+- `capabilities` (array)
+
+For agent-pack discovery, include:
+
+- `agent_manifests` (array of relative paths)
+
+Optional trust and compatibility metadata:
+
+- `tags` (array of strings)
+- `min_runtime_version` (string)
+- `signature` (string)
+
+Example:
+
+```toml
+name = "example-plugin"
+version = "0.4.0"
+wasm_path = "plugin.wasm"
+capabilities = ["tool"]
+permissions = ["http_client"]
+
+agent_manifests = [
+  "agents/researcher.toml",
+  "agents/triage.toml",
+]
+
+tags = ["agent-pack", "research"]
+min_runtime_version = "0.20.0"
+signature = "ed25519:..."
+```
+
+## Agent manifest requirements
+
+Each file listed in `agent_manifests` is loaded relative to `manifest.toml` and must include:
+
+- `schema_version` (integer)
+
+Compatibility is validated during registration. Agent manifests with newer schema versions than the runtime supports are rejected (fail-fast).
+
+## Trust controls
+
+- Marketplace install from `http(s)` sources is disabled by default.
+- Enable `[plugins].marketplace_enabled = true` to allow network installs.
+- Plugin requested permissions are checked against `[plugins].allowed_permissions` during install.

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -455,7 +455,11 @@ pub(crate) async fn dispatch_command(command: Commands, config: Config) -> Resul
             }
             PluginCommands::Install { source } => {
                 let mut host = rain_labs::plugins::host::PluginHost::new(&config.workspace_dir)?;
-                host.install(&source)?;
+                host.install_with_policy(
+                    &source,
+                    config.plugins.marketplace_enabled,
+                    &config.plugins.allowed_permissions,
+                )?;
                 println!("Plugin installed from {source}");
                 Ok(())
             }

--- a/src/config/schema/mod.rs
+++ b/src/config/schema/mod.rs
@@ -2296,6 +2296,12 @@ pub struct PluginsConfig {
     /// Maximum number of plugins that can be loaded
     #[serde(default = "default_max_plugins")]
     pub max_plugins: usize,
+    /// Allow network marketplace sources (`http(s)`) during plugin install.
+    #[serde(default)]
+    pub marketplace_enabled: bool,
+    /// Permissions explicitly allowed during plugin installation.
+    #[serde(default = "default_allowed_plugin_permissions")]
+    pub allowed_permissions: Vec<String>,
 }
 
 fn default_plugins_dir() -> String {
@@ -2306,6 +2312,17 @@ fn default_max_plugins() -> usize {
     50
 }
 
+fn default_allowed_plugin_permissions() -> Vec<String> {
+    vec![
+        "http_client".to_string(),
+        "file_read".to_string(),
+        "file_write".to_string(),
+        "env_read".to_string(),
+        "memory_read".to_string(),
+        "memory_write".to_string(),
+    ]
+}
+
 impl Default for PluginsConfig {
     fn default() -> Self {
         Self {
@@ -2313,6 +2330,8 @@ impl Default for PluginsConfig {
             plugins_dir: default_plugins_dir(),
             auto_discover: false,
             max_plugins: default_max_plugins(),
+            marketplace_enabled: false,
+            allowed_permissions: default_allowed_plugin_permissions(),
         }
     }
 }

--- a/src/gateway/api_plugins.rs
+++ b/src/gateway/api_plugins.rs
@@ -32,45 +32,69 @@ pub mod plugin_routes {
         let plugins_dir = config.plugins.plugins_dir.clone();
         drop(config);
 
-        let plugins: Vec<serde_json::Value> = if plugins_enabled {
-            let plugin_path = if plugins_dir.starts_with("~/") {
-                directories::UserDirs::new()
-                    .map(|u| u.home_dir().join(&plugins_dir[2..]))
-                    .unwrap_or_else(|| std::path::PathBuf::from(&plugins_dir))
-            } else {
-                std::path::PathBuf::from(&plugins_dir)
-            };
+        let (plugins, agent_packs): (Vec<serde_json::Value>, Vec<serde_json::Value>) =
+            if plugins_enabled {
+                let plugin_path = if plugins_dir.starts_with("~/") {
+                    directories::UserDirs::new()
+                        .map(|u| u.home_dir().join(&plugins_dir[2..]))
+                        .unwrap_or_else(|| std::path::PathBuf::from(&plugins_dir))
+                } else {
+                    std::path::PathBuf::from(&plugins_dir)
+                };
 
-            if plugin_path.exists() {
-                match crate::plugins::host::PluginHost::new(
-                    plugin_path.parent().unwrap_or(&plugin_path),
-                ) {
-                    Ok(host) => host
-                        .list_plugins()
-                        .into_iter()
-                        .map(|p| {
-                            serde_json::json!({
-                                "name": p.name,
-                                "version": p.version,
-                                "description": p.description,
-                                "capabilities": p.capabilities,
-                                "loaded": p.loaded,
-                            })
-                        })
-                        .collect(),
-                    Err(_) => vec![],
+                if plugin_path.exists() {
+                    match crate::plugins::host::PluginHost::new(
+                        plugin_path.parent().unwrap_or(&plugin_path),
+                    ) {
+                        Ok(host) => {
+                            let plugins = host
+                                .list_plugins()
+                                .into_iter()
+                                .map(|p| {
+                                    serde_json::json!({
+                                        "name": p.name,
+                                        "version": p.version,
+                                        "description": p.description,
+                                        "tags": p.tags,
+                                        "min_runtime_version": p.min_runtime_version,
+                                        "signature": p.signature,
+                                        "capabilities": p.capabilities,
+                                        "loaded": p.loaded,
+                                    })
+                                })
+                                .collect();
+
+                            let agent_packs = host
+                                .list_agent_packs()
+                                .into_iter()
+                                .map(|p| {
+                                    serde_json::json!({
+                                        "plugin": p.plugin,
+                                        "manifest_path": p.manifest_path,
+                                        "schema_version": p.schema_version,
+                                        "tags": p.tags,
+                                        "min_runtime_version": p.min_runtime_version,
+                                        "signature": p.signature,
+                                    })
+                                })
+                                .collect();
+
+                            (plugins, agent_packs)
+                        }
+                        Err(_) => (vec![], vec![]),
+                    }
+                } else {
+                    (vec![], vec![])
                 }
             } else {
-                vec![]
-            }
-        } else {
-            vec![]
-        };
+                (vec![], vec![])
+            };
 
         Json(serde_json::json!({
             "plugins_enabled": plugins_enabled,
             "plugins_dir": plugins_dir,
             "plugins": plugins,
+            "agent_packs": agent_packs,
         }))
         .into_response()
     }

--- a/src/plugins/host.rs
+++ b/src/plugins/host.rs
@@ -359,8 +359,12 @@ impl PluginHost {
         let manifest_url = if source.path().ends_with("manifest.toml") {
             source.clone()
         } else {
-            let base = ensure_trailing_slash(source);
-            base.join("manifest.toml")
+            let mut base = source.clone();
+            if !base.path().ends_with('/') {
+                base.set_path(&format!("{}/", base.path()));
+            }
+            base
+                .join("manifest.toml")
                 .map_err(|e| PluginError::LoadFailed(format!("invalid marketplace URL: {e}")))?
         };
 

--- a/src/plugins/host.rs
+++ b/src/plugins/host.rs
@@ -150,6 +150,14 @@ impl PluginHost {
         }
 
         let manifest = self.load_manifest(&manifest_path)?;
+
+        // Validate manifest fields against path traversal before any file operations.
+        validate_relative_path(&manifest.name, "plugin name")?;
+        validate_relative_path(&manifest.wasm_path, "wasm_path")?;
+        for agent_manifest in &manifest.agent_manifests {
+            validate_relative_path(agent_manifest, "agent_manifests entry")?;
+        }
+
         self.validate_requested_permissions(&manifest, allowed_permissions)?;
         let source_dir = manifest_path
             .parent()
@@ -351,8 +359,8 @@ impl PluginHost {
         let manifest_url = if source.path().ends_with("manifest.toml") {
             source.clone()
         } else {
-            source
-                .join("manifest.toml")
+            let base = ensure_trailing_slash(source);
+            base.join("manifest.toml")
                 .map_err(|e| PluginError::LoadFailed(format!("invalid marketplace URL: {e}")))?
         };
 
@@ -378,7 +386,9 @@ impl PluginHost {
         staging_dir: &Path,
         relative_path: &str,
     ) -> Result<PathBuf, PluginError> {
-        let remote = source.join(relative_path).map_err(|e| {
+        validate_relative_path(relative_path, "marketplace artifact path")?;
+        let base = ensure_trailing_slash(source);
+        let remote = base.join(relative_path).map_err(|e| {
             PluginError::LoadFailed(format!("invalid marketplace artifact URL: {e}"))
         })?;
         let bytes = reqwest::blocking::get(remote.clone())
@@ -395,6 +405,39 @@ impl PluginHost {
         std::fs::write(&local, bytes)?;
         Ok(local)
     }
+}
+
+/// Ensure a URL ends with a trailing slash so that `Url::join` appends
+/// rather than replacing the last path segment (RFC 3986 behaviour).
+fn ensure_trailing_slash(url: &Url) -> Url {
+    let mut base = url.clone();
+    if !base.path().ends_with('/') {
+        base.set_path(&format!("{}/", base.path()));
+    }
+    base
+}
+
+/// Reject paths that could escape the target directory.
+fn validate_relative_path(path: &str, field_name: &str) -> Result<(), PluginError> {
+    if path.is_empty() {
+        return Err(PluginError::InvalidManifest(format!(
+            "{field_name} must not be empty"
+        )));
+    }
+    let p = std::path::Path::new(path);
+    if p.is_absolute() {
+        return Err(PluginError::InvalidManifest(format!(
+            "{field_name} contains absolute path: {path}"
+        )));
+    }
+    for component in p.components() {
+        if matches!(component, std::path::Component::ParentDir) {
+            return Err(PluginError::InvalidManifest(format!(
+                "{field_name} contains path traversal (..): {path}"
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn parse_marketplace_source(source: &str) -> Option<Url> {

--- a/src/plugins/host.rs
+++ b/src/plugins/host.rs
@@ -386,12 +386,16 @@ impl PluginHost {
 
     fn fetch_marketplace_file(
         &self,
+    fn fetch_marketplace_file(
+        &self,
         source: &Url,
         staging_dir: &Path,
         relative_path: &str,
     ) -> Result<PathBuf, PluginError> {
-        validate_relative_path(relative_path, "marketplace artifact path")?;
-        let base = ensure_trailing_slash(source);
+        let mut base = source.clone();
+        if !base.path().ends_with('/') {
+            base.set_path(&format!("{}/", base.path()));
+        }
         let remote = base.join(relative_path).map_err(|e| {
             PluginError::LoadFailed(format!("invalid marketplace artifact URL: {e}"))
         })?;

--- a/src/plugins/host.rs
+++ b/src/plugins/host.rs
@@ -1,7 +1,11 @@
 //! Plugin host: discovery, loading, lifecycle management.
 
 use super::error::PluginError;
-use super::{PluginCapability, PluginInfo, PluginManifest};
+use super::{
+    AgentPackInfo, PluginCapability, PluginInfo, PluginManifest, PluginPermission,
+    AGENT_MANIFEST_SCHEMA_VERSION,
+};
+use reqwest::Url;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
@@ -9,10 +13,12 @@ use std::path::{Path, PathBuf};
 pub struct PluginHost {
     plugins_dir: PathBuf,
     loaded: HashMap<String, LoadedPlugin>,
+    agent_registry: HashMap<PathBuf, AgentPackInfo>,
 }
 
 struct LoadedPlugin {
     manifest: PluginManifest,
+    manifest_dir: PathBuf,
     wasm_path: PathBuf,
 }
 
@@ -27,6 +33,7 @@ impl PluginHost {
         let mut host = Self {
             plugins_dir,
             loaded: HashMap::new(),
+            agent_registry: HashMap::new(),
         };
 
         host.discover()?;
@@ -47,10 +54,12 @@ impl PluginHost {
                 if manifest_path.exists() {
                     if let Ok(manifest) = self.load_manifest(&manifest_path) {
                         let wasm_path = path.join(&manifest.wasm_path);
+                        let manifest_dir = manifest_path.parent().unwrap_or(&path).to_path_buf();
                         self.loaded.insert(
                             manifest.name.clone(),
                             LoadedPlugin {
                                 manifest,
+                                manifest_dir,
                                 wasm_path,
                             },
                         );
@@ -59,6 +68,7 @@ impl PluginHost {
             }
         }
 
+        self.rebuild_agent_registry()?;
         Ok(())
     }
 
@@ -76,6 +86,9 @@ impl PluginHost {
                 name: p.manifest.name.clone(),
                 version: p.manifest.version.clone(),
                 description: p.manifest.description.clone(),
+                tags: p.manifest.tags.clone(),
+                min_runtime_version: p.manifest.min_runtime_version.clone(),
+                signature: p.manifest.signature.clone(),
                 capabilities: p.manifest.capabilities.clone(),
                 permissions: p.manifest.permissions.clone(),
                 wasm_path: p.wasm_path.clone(),
@@ -90,6 +103,9 @@ impl PluginHost {
             name: p.manifest.name.clone(),
             version: p.manifest.version.clone(),
             description: p.manifest.description.clone(),
+            tags: p.manifest.tags.clone(),
+            min_runtime_version: p.manifest.min_runtime_version.clone(),
+            signature: p.manifest.signature.clone(),
             capabilities: p.manifest.capabilities.clone(),
             permissions: p.manifest.permissions.clone(),
             wasm_path: p.wasm_path.clone(),
@@ -99,8 +115,28 @@ impl PluginHost {
 
     /// Install a plugin from a directory path.
     pub fn install(&mut self, source: &str) -> Result<(), PluginError> {
+        self.install_with_policy(source, false, &all_permissions())
+    }
+
+    /// Install a plugin with config-driven trust controls.
+    pub fn install_with_policy(
+        &mut self,
+        source: &str,
+        marketplace_enabled: bool,
+        allowed_permissions: &[String],
+    ) -> Result<(), PluginError> {
+        let marketplace_url = parse_marketplace_source(source);
+        if marketplace_url.is_some() && !marketplace_enabled {
+            return Err(PluginError::PermissionDenied {
+                plugin: source.to_string(),
+                permission: "plugins.marketplace_enabled".to_string(),
+            });
+        }
+
         let source_path = PathBuf::from(source);
-        let manifest_path = if source_path.is_dir() {
+        let manifest_path = if let Some(url) = marketplace_url.as_ref() {
+            self.fetch_marketplace_manifest(url)?
+        } else if source_path.is_dir() {
             source_path.join("manifest.toml")
         } else {
             source_path.clone()
@@ -114,16 +150,27 @@ impl PluginHost {
         }
 
         let manifest = self.load_manifest(&manifest_path)?;
+        self.validate_requested_permissions(&manifest, allowed_permissions)?;
         let source_dir = manifest_path
             .parent()
             .ok_or_else(|| PluginError::InvalidManifest("no parent directory".into()))?;
 
-        let wasm_source = source_dir.join(&manifest.wasm_path);
+        let wasm_source = if let Some(url) = marketplace_url.as_ref() {
+            self.fetch_marketplace_file(url, source_dir, &manifest.wasm_path)?
+        } else {
+            source_dir.join(&manifest.wasm_path)
+        };
         if !wasm_source.exists() {
             return Err(PluginError::NotFound(format!(
                 "WASM file not found: {}",
                 wasm_source.display()
             )));
+        }
+
+        if let Some(url) = marketplace_url.as_ref() {
+            for agent_manifest in &manifest.agent_manifests {
+                let _ = self.fetch_marketplace_file(url, source_dir, agent_manifest)?;
+            }
         }
 
         if self.loaded.contains_key(&manifest.name) {
@@ -144,14 +191,32 @@ impl PluginHost {
         }
         std::fs::copy(&wasm_source, &wasm_dest)?;
 
+        // Copy declared agent manifests
+        for agent_manifest in &manifest.agent_manifests {
+            let src = source_dir.join(agent_manifest);
+            if !src.exists() {
+                return Err(PluginError::NotFound(format!(
+                    "Agent manifest not found: {}",
+                    src.display()
+                )));
+            }
+            let dest = dest_dir.join(agent_manifest);
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::copy(src, dest)?;
+        }
+
         self.loaded.insert(
             manifest.name.clone(),
             LoadedPlugin {
                 manifest,
+                manifest_dir: dest_dir,
                 wasm_path: wasm_dest,
             },
         );
 
+        self.rebuild_agent_registry()?;
         Ok(())
     }
 
@@ -166,6 +231,7 @@ impl PluginHost {
             std::fs::remove_dir_all(plugin_dir)?;
         }
 
+        self.rebuild_agent_registry()?;
         Ok(())
     }
 
@@ -187,10 +253,183 @@ impl PluginHost {
             .collect()
     }
 
+    /// List plugin-provided agent packs registered from local manifests.
+    pub fn list_agent_packs(&self) -> Vec<AgentPackInfo> {
+        self.agent_registry.values().cloned().collect()
+    }
+
+    /// Get the in-memory registry of resolved plugin-provided agent manifests.
+    pub fn agent_registry(&self) -> &HashMap<PathBuf, AgentPackInfo> {
+        &self.agent_registry
+    }
+
     /// Returns the plugins directory path.
     pub fn plugins_dir(&self) -> &Path {
         &self.plugins_dir
     }
+
+    fn rebuild_agent_registry(&mut self) -> Result<(), PluginError> {
+        self.agent_registry.clear();
+
+        for loaded in self.loaded.values() {
+            for relative_manifest in &loaded.manifest.agent_manifests {
+                let resolved = loaded.manifest_dir.join(relative_manifest);
+                let info = self.register_agent_manifest(
+                    &loaded.manifest.name,
+                    &resolved,
+                    &loaded.manifest.tags,
+                    loaded.manifest.min_runtime_version.as_deref(),
+                    loaded.manifest.signature.as_deref(),
+                )?;
+                self.agent_registry.insert(resolved, info);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn register_agent_manifest(
+        &self,
+        plugin_name: &str,
+        manifest_path: &Path,
+        plugin_tags: &[String],
+        min_runtime_version: Option<&str>,
+        signature: Option<&str>,
+    ) -> Result<AgentPackInfo, PluginError> {
+        if !manifest_path.exists() {
+            return Err(PluginError::NotFound(format!(
+                "agent manifest not found: {}",
+                manifest_path.display()
+            )));
+        }
+
+        let content = std::fs::read_to_string(manifest_path)?;
+        let value: toml::Value = toml::from_str(&content)?;
+        let schema_version = extract_schema_version(&value).ok_or_else(|| {
+            PluginError::InvalidManifest(format!(
+                "agent manifest '{}' must define integer schema_version",
+                manifest_path.display()
+            ))
+        })?;
+        if schema_version > AGENT_MANIFEST_SCHEMA_VERSION {
+            return Err(PluginError::InvalidManifest(format!(
+                "agent manifest '{}' schema_version {} is newer than supported {}",
+                manifest_path.display(),
+                schema_version,
+                AGENT_MANIFEST_SCHEMA_VERSION
+            )));
+        }
+
+        Ok(AgentPackInfo {
+            plugin: plugin_name.to_string(),
+            manifest_path: manifest_path.to_path_buf(),
+            schema_version,
+            tags: plugin_tags.to_vec(),
+            min_runtime_version: min_runtime_version.map(str::to_string),
+            signature: signature.map(str::to_string),
+        })
+    }
+
+    fn validate_requested_permissions(
+        &self,
+        manifest: &PluginManifest,
+        allowed_permissions: &[String],
+    ) -> Result<(), PluginError> {
+        for permission in &manifest.permissions {
+            let key = permission_key(permission);
+            if !allowed_permissions.iter().any(|p| p == key) {
+                return Err(PluginError::PermissionDenied {
+                    plugin: manifest.name.clone(),
+                    permission: key.to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn fetch_marketplace_manifest(&self, source: &Url) -> Result<PathBuf, PluginError> {
+        let manifest_url = if source.path().ends_with("manifest.toml") {
+            source.clone()
+        } else {
+            source
+                .join("manifest.toml")
+                .map_err(|e| PluginError::LoadFailed(format!("invalid marketplace URL: {e}")))?
+        };
+
+        let content = reqwest::blocking::get(manifest_url.clone())
+            .map_err(|e| PluginError::LoadFailed(format!("failed to fetch {manifest_url}: {e}")))?
+            .error_for_status()
+            .map_err(|e| PluginError::LoadFailed(format!("failed to fetch {manifest_url}: {e}")))?
+            .text()
+            .map_err(|e| {
+                PluginError::LoadFailed(format!("failed to read response from {manifest_url}: {e}"))
+            })?;
+
+        let staging_dir = self.plugins_dir.join(".marketplace-staging");
+        std::fs::create_dir_all(&staging_dir)?;
+        let manifest_path = staging_dir.join("manifest.toml");
+        std::fs::write(&manifest_path, content)?;
+        Ok(manifest_path)
+    }
+
+    fn fetch_marketplace_file(
+        &self,
+        source: &Url,
+        staging_dir: &Path,
+        relative_path: &str,
+    ) -> Result<PathBuf, PluginError> {
+        let remote = source.join(relative_path).map_err(|e| {
+            PluginError::LoadFailed(format!("invalid marketplace artifact URL: {e}"))
+        })?;
+        let bytes = reqwest::blocking::get(remote.clone())
+            .map_err(|e| PluginError::LoadFailed(format!("failed to fetch {remote}: {e}")))?
+            .error_for_status()
+            .map_err(|e| PluginError::LoadFailed(format!("failed to fetch {remote}: {e}")))?
+            .bytes()
+            .map_err(|e| PluginError::LoadFailed(format!("failed to read {remote}: {e}")))?;
+
+        let local = staging_dir.join(relative_path);
+        if let Some(parent) = local.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&local, bytes)?;
+        Ok(local)
+    }
+}
+
+fn parse_marketplace_source(source: &str) -> Option<Url> {
+    Url::parse(source)
+        .ok()
+        .filter(|url| matches!(url.scheme(), "http" | "https"))
+}
+
+fn extract_schema_version(value: &toml::Value) -> Option<u32> {
+    value
+        .get("schema_version")
+        .and_then(toml::Value::as_integer)
+        .and_then(|v| u32::try_from(v).ok())
+}
+
+fn permission_key(permission: &PluginPermission) -> &'static str {
+    match permission {
+        PluginPermission::HttpClient => "http_client",
+        PluginPermission::FileRead => "file_read",
+        PluginPermission::FileWrite => "file_write",
+        PluginPermission::EnvRead => "env_read",
+        PluginPermission::MemoryRead => "memory_read",
+        PluginPermission::MemoryWrite => "memory_write",
+    }
+}
+
+fn all_permissions() -> Vec<String> {
+    vec![
+        "http_client".to_string(),
+        "file_read".to_string(),
+        "file_write".to_string(),
+        "env_read".to_string(),
+        "memory_read".to_string(),
+        "memory_write".to_string(),
+    ]
 }
 
 #[cfg(test)]
@@ -321,5 +560,102 @@ capabilities = ["tool"]
         let dir = tempdir().unwrap();
         let mut host = PluginHost::new(dir.path()).unwrap();
         assert!(host.remove("ghost").is_err());
+    }
+
+    #[test]
+    fn test_discover_agent_pack_manifests() {
+        let dir = tempdir().unwrap();
+        let plugin_dir = dir.path().join("plugins").join("agent-plugin");
+        std::fs::create_dir_all(plugin_dir.join("agents")).unwrap();
+
+        std::fs::write(
+            plugin_dir.join("manifest.toml"),
+            r#"
+name = "agent-plugin"
+version = "0.3.0"
+wasm_path = "plugin.wasm"
+agent_manifests = ["agents/researcher.toml"]
+tags = ["research", "pack"]
+min_runtime_version = "0.20.0"
+signature = "sig:abc123"
+capabilities = ["tool"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            plugin_dir.join("agents").join("researcher.toml"),
+            r#"
+schema_version = 1
+name = "researcher"
+"#,
+        )
+        .unwrap();
+
+        let host = PluginHost::new(dir.path()).unwrap();
+        let packs = host.list_agent_packs();
+        assert_eq!(packs.len(), 1);
+        assert_eq!(packs[0].plugin, "agent-plugin");
+        assert_eq!(packs[0].schema_version, 1);
+        assert_eq!(packs[0].tags, vec!["research", "pack"]);
+    }
+
+    #[test]
+    fn test_discover_agent_pack_schema_version_incompatible_fails_fast() {
+        let dir = tempdir().unwrap();
+        let plugin_dir = dir.path().join("plugins").join("bad-agent-pack");
+        std::fs::create_dir_all(plugin_dir.join("agents")).unwrap();
+
+        std::fs::write(
+            plugin_dir.join("manifest.toml"),
+            r#"
+name = "bad-agent-pack"
+version = "0.1.0"
+wasm_path = "plugin.wasm"
+agent_manifests = ["agents/latest.toml"]
+capabilities = ["tool"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            plugin_dir.join("agents").join("latest.toml"),
+            r#"
+schema_version = 999
+name = "future-pack"
+"#,
+        )
+        .unwrap();
+
+        let result = PluginHost::new(dir.path());
+        assert!(matches!(result, Err(PluginError::InvalidManifest(_))));
+    }
+
+    #[test]
+    fn test_install_with_policy_rejects_disallowed_permissions() {
+        let dir = tempdir().unwrap();
+        let source = dir.path().join("source-plugin");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("plugin.wasm"), b"\0asm").unwrap();
+        std::fs::write(
+            source.join("manifest.toml"),
+            r#"
+name = "perm-test"
+version = "1.0.0"
+wasm_path = "plugin.wasm"
+capabilities = ["tool"]
+permissions = ["env_read"]
+"#,
+        )
+        .unwrap();
+
+        let mut host = PluginHost::new(dir.path()).unwrap();
+        let allowed_permissions = vec!["http_client".to_string()];
+
+        let err = host
+            .install_with_policy(source.to_str().unwrap(), false, &allowed_permissions)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            PluginError::PermissionDenied { permission, .. } if permission == "env_read"
+        ));
     }
 }

--- a/src/plugins/host.rs
+++ b/src/plugins/host.rs
@@ -49,6 +49,13 @@ impl PluginHost {
         let entries = std::fs::read_dir(&self.plugins_dir)?;
         for entry in entries.flatten() {
             let path = entry.path();
+            // Skip hidden/internal directories (e.g. .marketplace-staging)
+            if path
+                .file_name()
+                .map_or(false, |n| n.to_string_lossy().starts_with('.'))
+            {
+                continue;
+            }
             if path.is_dir() {
                 let manifest_path = path.join("manifest.toml");
                 if manifest_path.exists() {
@@ -223,6 +230,12 @@ impl PluginHost {
                 wasm_path: wasm_dest,
             },
         );
+
+        // Clean up marketplace staging directory if it exists.
+        let staging_dir = self.plugins_dir.join(".marketplace-staging");
+        if staging_dir.exists() {
+            let _ = std::fs::remove_dir_all(&staging_dir);
+        }
 
         self.rebuild_agent_registry()?;
         Ok(())

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -11,6 +11,9 @@ pub mod wasm_tool;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Current supported schema version for plugin-provided agent manifests.
+pub const AGENT_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
 /// A plugin's declared manifest (loaded from manifest.toml alongside the .wasm).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginManifest {
@@ -24,6 +27,16 @@ pub struct PluginManifest {
     pub author: Option<String>,
     /// Path to the .wasm file (relative to manifest)
     pub wasm_path: String,
+    /// Optional plugin-provided agent manifest paths (relative to manifest)
+    #[serde(default)]
+    pub agent_manifests: Vec<String>,
+    /// Optional discoverability tags
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Optional minimum required runtime version
+    pub min_runtime_version: Option<String>,
+    /// Optional signature used for plugin integrity verification
+    pub signature: Option<String>,
     /// Capabilities this plugin provides
     pub capabilities: Vec<PluginCapability>,
     /// Permissions this plugin requests
@@ -69,8 +82,22 @@ pub struct PluginInfo {
     pub name: String,
     pub version: String,
     pub description: Option<String>,
+    pub tags: Vec<String>,
+    pub min_runtime_version: Option<String>,
+    pub signature: Option<String>,
     pub capabilities: Vec<PluginCapability>,
     pub permissions: Vec<PluginPermission>,
     pub wasm_path: PathBuf,
     pub loaded: bool,
+}
+
+/// Discovery metadata for a plugin-provided agent manifest.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentPackInfo {
+    pub plugin: String,
+    pub manifest_path: PathBuf,
+    pub schema_version: u32,
+    pub tags: Vec<String>,
+    pub min_runtime_version: Option<String>,
+    pub signature: Option<String>,
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -736,11 +736,11 @@ pub fn all_tools_with_runtime(
     #[cfg(feature = "plugins-wasm")]
     {
         let plugin_dir = config.plugins.plugins_dir.clone();
-        let plugin_path = if plugin_dir.starts_with("~/") {
+        let plugin_path = if let Some(stripped) = plugin_dir.strip_prefix("~/") {
             let home = directories::UserDirs::new()
                 .map(|u| u.home_dir().to_path_buf())
                 .unwrap_or_else(|| std::path::PathBuf::from("."));
-            home.join(&plugin_dir[2..])
+            home.join(stripped)
         } else {
             std::path::PathBuf::from(&plugin_dir)
         };


### PR DESCRIPTION
### Motivation

- Allow WASM plugins to ship agent-pack manifests so the orchestrator can discover and register metadata-only agent packs without requiring the execution bridge. 
- Provide compatibility and trust controls for plugin-supplied agent packs by validating manifest schema versions and gating network marketplace installs and permission grants.
- Surface plugin-provided agent metadata via the API and document the packaging/manifest requirements for plugin authors.

### Description

- Extended `PluginManifest` and `PluginInfo` in `src/plugins/mod.rs` with optional fields `agent_manifests`, `tags`, `min_runtime_version`, and `signature`, and added `AgentPackInfo` plus `AGENT_MANIFEST_SCHEMA_VERSION` constant.
- Enhanced `PluginHost` (`src/plugins/host.rs`) to maintain an in-memory `agent_registry`, implement `rebuild_agent_registry()` and `list_agent_packs()`, and perform `schema_version` compatibility checks when registering plugin-provided agent manifests (fail-fast on newer/incompatible schema).
- Added a policy-aware install flow `install_with_policy()` that enforces a `marketplace_enabled` gate and an install-time `allowed_permissions` allowlist; added marketplace fetch helpers to stage remote manifests/artifacts and copy plugin-relative agent manifests into the plugins directory during install.
- Kept existing fail-fast behavior for WASM execution bridge absence while enabling metadata-only agent-pack discovery via the host registry.
- Wired config surface and CLI: added `[plugins].marketplace_enabled` and `[plugins].allowed_permissions` to `src/config/schema/mod.rs`, passed those controls from the CLI (`src/cli/dispatch.rs`) into plugin installs, and returned agent-pack metadata from the management API (`src/gateway/api_plugins.rs`).
- Added authoring documentation `docs/reference/plugin-agent-pack-authoring.md` and updated config reference pages (EN/FR/VI) to describe the new plugin config keys and behavior.
- Added unit tests covering agent-pack discovery, schema-version incompatibility rejection, and install permission gating; also applied a small clippy-friendly path fix (`strip_prefix`) in `src/tools/mod.rs`.

### Testing

- Ran `cargo fmt --all` and it completed successfully.
- Ran `cargo clippy --all-targets --features plugins-wasm -- -D warnings` and it completed successfully.
- Executed the plugin-host unit tests with `cargo test --lib --features plugins-wasm plugins::host::tests` and all relevant tests passed (`test_discover_agent_pack_manifests`, `test_discover_agent_pack_schema_version_incompatible_fails_fast`, `test_install_with_policy_rejects_disallowed_permissions`, plus existing host tests — 9 passed, 0 failed).
- Note: an initial `cargo test` attempt encountered an environment disk exhaustion (`No space left on device`); build artifacts were cleaned and the tests were re-run successfully after cleanup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c29d27e5c08324ae472ec8812d2b05)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
