### PR TITLE
fix(agent): use manifest identity locals in prompt formatter

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -638,21 +638,7 @@ impl Agent {
             let _ = write!(
                 prompt,
                 "- Agent: {}\n- Role: {}\n\n{}",
-                manifest
-                    .identity
-                    .name
-                    .as_deref()
-                    .unwrap_or("unknown"),
-                manifest
-                    .identity
-                    .role
-                    .as_deref()
-                    .unwrap_or("unknown"),
-                manifest
-                    .identity
-                    .system_prompt
-                    .as_deref()
-                    .unwrap_or_default()
+                name, role, system_prompt
             );
         }
         Ok(prompt)


### PR DESCRIPTION
### Motivation
- Fix a CI failure where `cargo fmt` and strict-delta linting reported diffs and `unused_variables` errors caused by reading manifest fields inline instead of using already-declared local bindings in the system prompt assembly.

### Description
- In `src/agent/agent.rs` replaced the inline `manifest.identity.*` accesses in the `write!` call with the local `name`, `role`, and `system_prompt` bindings so the prompt formatter uses the values that were already computed.

### Testing
- Ran formatting checks: `cargo fmt --all` and `cargo fmt --all -- --check` completed successfully, and the change is formatted as expected; the repository CI helper `bash scripts/ci/rust_strict_delta_gate.sh` (which drives `clippy` and additional checks) was started but the full compile/lint pass is compilation-heavy and remained in-progress in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c2c945da288323a40f6d81f2996b13)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
