### PR TITLE
fix(tools): require explicit allowlist match alongside profiles

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -330,14 +330,13 @@ fn filter_tool_pool_arcs(
     denylist: &[String],
     profiles: &[String],
 ) -> Vec<Arc<dyn Tool>> {
-    let mut allow_selectors = expand_profiles(profiles);
-    allow_selectors.extend(
-        allowlist
-            .iter()
-            .map(|item| item.trim())
-            .filter(|item| !item.is_empty())
-            .map(ToOwned::to_owned),
-    );
+    let profile_selectors = expand_profiles(profiles);
+    let allow_selectors: HashSet<String> = allowlist
+        .iter()
+        .map(|item| item.trim())
+        .filter(|item| !item.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
     let deny_selectors: HashSet<String> = denylist
         .iter()
         .map(|item| item.trim())
@@ -345,21 +344,27 @@ fn filter_tool_pool_arcs(
         .map(ToOwned::to_owned)
         .collect();
 
-    let has_allow = !allow_selectors.is_empty();
+    let has_profile_allow = !profile_selectors.is_empty();
+    let has_explicit_allow = !allow_selectors.is_empty();
+    let profile_allow_vec: Vec<String> = profile_selectors.into_iter().collect();
     let allow_vec: Vec<String> = allow_selectors.into_iter().collect();
     let deny_vec: Vec<String> = deny_selectors.into_iter().collect();
 
     pool.into_iter()
         .filter(|tool| {
             let name = tool.name();
-            let allowed = !has_allow
+            let allowed_by_profiles = !has_profile_allow
+                || profile_allow_vec
+                    .iter()
+                    .any(|selector| selector_matches_tool(selector, name));
+            let allowed_by_explicit = !has_explicit_allow
                 || allow_vec
                     .iter()
                     .any(|selector| selector_matches_tool(selector, name));
             let denied = deny_vec
                 .iter()
                 .any(|selector| selector_matches_tool(selector, name));
-            allowed && !denied
+            allowed_by_profiles && allowed_by_explicit && !denied
         })
         .collect()
 }


### PR DESCRIPTION
### Motivation
- Prevent broad profile selectors from unintentionally widening explicit allowlist constraints during tool selection, which caused the failing test `filter_tool_pool_matches_mcp_alias_patterns`.

### Description
- Keep profile-derived selectors and explicit allowlist selectors separate and evaluate them independently instead of merging them into a single set.
- Require a tool to satisfy both `allowed_by_profiles` and `allowed_by_explicit` when the respective selector lists are non-empty, while preserving the existing denylist exclusion.
- Implemented the changes in `src/tools/mod.rs` inside `filter_tool_pool_arcs` by computing `profile_selectors` and `allow_selectors` separately and combining their results with an intersection check.

### Testing
- Ran `cargo fmt --all -- --check` which succeeded.
- Ran `cargo clippy --all-targets -- -D warnings` which succeeded (no warnings treated as errors).
- Ran targeted unit tests `cargo test --lib tools::tests::filter_tool_pool_matches_mcp_alias_patterns -- --exact` and `cargo test --lib tools::tests::filter_tool_pool_expands_profiles_and_applies_denylist -- --exact`, and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c2e56147d48323bf6c6684425bc71a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
