### PR TITLE
Add 'Capabilities At A Glance' and audience guidance to README

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -30,3 +30,23 @@ python rain_lab.py
 ```
 
 Pour les détails des commandes et de la configuration, consultez le hub docs et les références runtime.
+
+## Capacités en un coup d’œil (Capabilities At A Glance)
+
+Cette page est la porte d’entrée. Pour la surface runtime complète (commandes, channels, providers, opérations, sécurité, matériel), utilisez les références ci-dessous.
+
+| Domaine de capacité | Ce que vous obtenez | Référence canonique |
+| --- | --- | --- |
+| CLI et automatisation | Onboarding, agent, gateway/daemon, service, diagnostics, estop, cron, skills, mises à jour | [Commands Reference](docs/reference/cli/commands-reference.md) |
+| Channels et messagerie | Distribution multi-channel, allowlists, modes webhook/polling, config par channel | [Channels Reference](docs/reference/api/channels-reference.md) |
+| Providers et routage de modèles | Providers local/cloud, alias, variables d’authentification, rafraîchissement des modèles | [Providers Reference](docs/reference/api/providers-reference.md) |
+| Configuration et contrats runtime | Schéma de configuration et garanties de comportement | [Config Reference](docs/reference/api/config-reference.md) |
+| Opérations et dépannage | Runbook, modèles de déploiement, diagnostics et reprise sur incident | [Operations Runbook](docs/ops/operations-runbook.md), [Troubleshooting](docs/ops/troubleshooting.md) |
+| Modèle de sécurité | Sandbox, frontières de politiques, posture d’audit | [Security Docs Hub](docs/security/README.md) |
+| Matériel et périphériques | Configuration des cartes et design des outils périphériques | [Hardware Docs Hub](docs/hardware/README.md) |
+
+## Qui doit lire quoi ensuite (Who Should Read What Next)
+
+- **Nouveaux utilisateurs / première expérience** : commencez par [`START_HERE.md`](START_HERE.md), puis continuez avec [`docs/getting-started/README.md`](docs/getting-started/README.md).
+- **Opérateurs / responsables déploiement** : priorisez [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md) et [`docs/ops/troubleshooting.md`](docs/ops/troubleshooting.md).
+- **Intégrateurs / développeurs d’extensions** : priorisez [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md), [`docs/reference/api/config-reference.md`](docs/reference/api/config-reference.md), [`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md), [`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md).

--- a/README.fr.md
+++ b/README.fr.md
@@ -47,6 +47,6 @@ Cette page est la porte d’entrée. Pour la surface runtime complète (commande
 
 ## Qui doit lire quoi ensuite (Who Should Read What Next)
 
-- **Nouveaux utilisateurs / première expérience** : commencez par [`START_HERE.md`](START_HERE.md), puis continuez avec [`docs/getting-started/README.md`](docs/getting-started/README.md).
-- **Opérateurs / responsables déploiement** : priorisez [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md) et [`docs/ops/troubleshooting.md`](docs/ops/troubleshooting.md).
-- **Intégrateurs / développeurs d’extensions** : priorisez [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md), [`docs/reference/api/config-reference.md`](docs/reference/api/config-reference.md), [`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md), [`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md).
+- **Nouveaux utilisateurs / première expérience** : commencez par [`START_HERE.md`](START_HERE.md), puis [`docs/getting-started/README.md`](docs/getting-started/README.md), puis [`docs/troubleshooting.md`](docs/troubleshooting.md).
+- **Opérateurs / responsables déploiement** : priorisez [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md), [`docs/ops/network-deployment.md`](docs/ops/network-deployment.md), [`docs/security/README.md`](docs/security/README.md).
+- **Intégrateurs / développeurs d'extensions** : priorisez [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md), [`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md), [`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md).

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,6 +47,6 @@ python rain_lab.py
 
 ## 次に読むべき資料（Who Should Read What Next）
 
-- **新規ユーザー / 初回体験**：[`START_HERE.md`](START_HERE.md) から始め、次に [`docs/getting-started/README.md`](docs/getting-started/README.md) を参照。
-- **運用担当 / デプロイ担当**：[`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md) と [`docs/ops/troubleshooting.md`](docs/ops/troubleshooting.md) を優先。
-- **インテグレーター / 拡張開発者**：[`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md)、[`docs/reference/api/config-reference.md`](docs/reference/api/config-reference.md)、[`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md)、[`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md) を優先。
+- **新規ユーザー / 初回体験**：[`START_HERE.md`](START_HERE.md) から始め、次に [`docs/getting-started/README.md`](docs/getting-started/README.md)、そして [`docs/troubleshooting.md`](docs/troubleshooting.md) を参照。
+- **運用担当 / デプロイ担当**：[`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md)、[`docs/ops/network-deployment.md`](docs/ops/network-deployment.md)、[`docs/security/README.md`](docs/security/README.md) を優先。
+- **インテグレーター / 拡張開発者**：[`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md)、[`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md)、[`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md) を優先。

--- a/README.ja.md
+++ b/README.ja.md
@@ -30,3 +30,23 @@ python rain_lab.py
 ```
 
 実行コマンドや設定の詳細は docs ハブとリファレンスを参照してください。
+
+## 機能一覧（Capabilities At A Glance）
+
+このページは入口です。ランタイム全体の機能面（コマンド、チャネル、プロバイダー、運用、セキュリティ、ハードウェア）は次のリファレンスを参照してください。
+
+| 機能領域 | できること | 公式リファレンス |
+| --- | --- | --- |
+| CLI と自動化 | オンボーディング、agent、gateway/daemon、service、診断、estop、cron、skills、更新 | [Commands Reference](docs/reference/cli/commands-reference.md) |
+| チャネルとメッセージング | マルチチャネル配信、allowlist、webhook/polling モード、チャネル別設定 | [Channels Reference](docs/reference/api/channels-reference.md) |
+| プロバイダーとモデルルーティング | ローカル/クラウドプロバイダー、エイリアス、認証環境変数、モデル更新手順 | [Providers Reference](docs/reference/api/providers-reference.md) |
+| 設定とランタイム契約 | 設定スキーマと動作保証 | [Config Reference](docs/reference/api/config-reference.md) |
+| 運用とトラブルシューティング | Runbook、デプロイパターン、診断と障害復旧 | [Operations Runbook](docs/ops/operations-runbook.md), [Troubleshooting](docs/ops/troubleshooting.md) |
+| セキュリティモデル | サンドボックス、ポリシー境界、監査方針 | [Security Docs Hub](docs/security/README.md) |
+| ハードウェアと周辺機器 | ボード設定と周辺機器ツール設計 | [Hardware Docs Hub](docs/hardware/README.md) |
+
+## 次に読むべき資料（Who Should Read What Next）
+
+- **新規ユーザー / 初回体験**：[`START_HERE.md`](START_HERE.md) から始め、次に [`docs/getting-started/README.md`](docs/getting-started/README.md) を参照。
+- **運用担当 / デプロイ担当**：[`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md) と [`docs/ops/troubleshooting.md`](docs/ops/troubleshooting.md) を優先。
+- **インテグレーター / 拡張開発者**：[`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md)、[`docs/reference/api/config-reference.md`](docs/reference/api/config-reference.md)、[`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md)、[`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md) を優先。

--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ Before treating an extension as production-ready, read:
 - [Stability Tiers](docs/project/stability-tiers.md)
 - [Production Readiness](docs/PRODUCTION_READINESS.md)
 
+## Capabilities At A Glance
+
+README is the front door. For the complete runtime surface (commands, channels, providers, operations, security, hardware),
+use the linked references below.
+
+| Capability area | What you get | Canonical reference |
+| --- | --- | --- |
+| CLI and automation | Onboarding, agent, gateway/daemon, service, diagnostics, estop, cron, skills, updates | [Commands Reference](docs/reference/cli/commands-reference.md) |
+| Channels and messaging | Multi-channel delivery, allowlists, webhook/polling modes, per-channel config | [Channels Reference](docs/reference/api/channels-reference.md) |
+| Providers and model routing | Local/cloud providers, aliases, auth env vars, model refresh workflows | [Providers Reference](docs/reference/api/providers-reference.md) |
+| Config and runtime contracts | Config schema and behavior guarantees | [Config Reference](docs/reference/api/config-reference.md) |
+| Operations and troubleshooting | Runbook, deployment patterns, diagnostics and failure recovery | [Operations Runbook](docs/ops/operations-runbook.md), [Troubleshooting](docs/ops/troubleshooting.md) |
+| Security model | Sandboxing, policy boundaries, audit posture | [Security Docs Hub](docs/security/README.md) |
+| Hardware and peripherals | Board setup and peripheral tool design | [Hardware Docs Hub](docs/hardware/README.md) |
+
 ## What Makes It Different
 
 Most AI tools follow a simple pattern: prompt, answer, retry.
@@ -220,6 +235,12 @@ cargo build --release --locked --features channel-matrix,channel-lark,memory-pos
 - [Setup Guides](docs/setup-guides/README.md)
 - [Releases Page](https://github.com/topherchris420/james_library/releases)
 - [Troubleshooting](docs/troubleshooting.md)
+
+## Who Should Read What Next
+
+- **New users**: [START_HERE.md](START_HERE.md) -> [Getting Started Docs](docs/getting-started/README.md) -> [Troubleshooting](docs/troubleshooting.md)
+- **Operators**: [Operations Runbook](docs/ops/operations-runbook.md) -> [Network Deployment](docs/ops/network-deployment.md) -> [Security Docs Hub](docs/security/README.md)
+- **Integrators / developers**: [Commands Reference](docs/reference/cli/commands-reference.md) -> [Providers Reference](docs/reference/api/providers-reference.md) -> [Channels Reference](docs/reference/api/channels-reference.md)
 
 ## License
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -30,3 +30,23 @@ python rain_lab.py
 ```
 
 Подробности по командам и конфигурации доступны в docs-хабе и справочных разделах.
+
+## Возможности в одном месте (Capabilities At A Glance)
+
+Эта страница — входная точка. Для полного покрытия runtime-поверхности (команды, каналы, провайдеры, эксплуатация, безопасность, железо) используйте ссылки ниже.
+
+| Область возможностей | Что доступно | Канонический справочник |
+| --- | --- | --- |
+| CLI и автоматизация | Онбординг, agent, gateway/daemon, service, диагностика, estop, cron, skills, обновления | [Commands Reference](docs/reference/cli/commands-reference.md) |
+| Каналы и сообщения | Мультиканальная доставка, allowlists, режимы webhook/polling, конфиг по каналам | [Channels Reference](docs/reference/api/channels-reference.md) |
+| Провайдеры и маршрутизация моделей | Локальные/облачные провайдеры, алиасы, env-переменные авторизации, обновление моделей | [Providers Reference](docs/reference/api/providers-reference.md) |
+| Конфигурация и runtime-контракты | Схема конфигурации и поведенческие гарантии | [Config Reference](docs/reference/api/config-reference.md) |
+| Эксплуатация и диагностика | Runbook, паттерны деплоя, диагностика и восстановление после сбоев | [Operations Runbook](docs/ops/operations-runbook.md), [Troubleshooting](docs/ops/troubleshooting.md) |
+| Модель безопасности | Песочница, границы политик, аудит | [Security Docs Hub](docs/security/README.md) |
+| Оборудование и периферия | Настройка плат и дизайн инструментов периферии | [Hardware Docs Hub](docs/hardware/README.md) |
+
+## Что читать дальше по роли (Who Should Read What Next)
+
+- **Новые пользователи / первый запуск**: начните с [`START_HERE.md`](START_HERE.md), затем перейдите к [`docs/getting-started/README.md`](docs/getting-started/README.md).
+- **Операторы / владельцы деплоя**: в первую очередь [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md) и [`docs/ops/troubleshooting.md`](docs/ops/troubleshooting.md).
+- **Интеграторы / разработчики расширений**: в первую очередь [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md), [`docs/reference/api/config-reference.md`](docs/reference/api/config-reference.md), [`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md), [`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md).

--- a/README.ru.md
+++ b/README.ru.md
@@ -47,6 +47,6 @@ python rain_lab.py
 
 ## Что читать дальше по роли (Who Should Read What Next)
 
-- **Новые пользователи / первый запуск**: начните с [`START_HERE.md`](START_HERE.md), затем перейдите к [`docs/getting-started/README.md`](docs/getting-started/README.md).
-- **Операторы / владельцы деплоя**: в первую очередь [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md) и [`docs/ops/troubleshooting.md`](docs/ops/troubleshooting.md).
-- **Интеграторы / разработчики расширений**: в первую очередь [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md), [`docs/reference/api/config-reference.md`](docs/reference/api/config-reference.md), [`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md), [`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md).
+- **Новые пользователи / первый запуск**: начните с [`START_HERE.md`](START_HERE.md), затем [`docs/getting-started/README.md`](docs/getting-started/README.md), затем [`docs/troubleshooting.md`](docs/troubleshooting.md).
+- **Операторы / владельцы деплоя**: в первую очередь [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md), [`docs/ops/network-deployment.md`](docs/ops/network-deployment.md), [`docs/security/README.md`](docs/security/README.md).
+- **Интеграторы / разработчики расширений**: в первую очередь [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md), [`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md), [`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md).

--- a/README.vi.md
+++ b/README.vi.md
@@ -47,6 +47,6 @@ Trang này là điểm vào. Để xem đầy đủ bề mặt runtime (lệnh, 
 
 ## Ai nên đọc gì tiếp theo (Who Should Read What Next)
 
-- **Người dùng mới / lần đầu trải nghiệm**: bắt đầu từ [`START_HERE.md`](START_HERE.md), sau đó đọc [`docs/getting-started/README.md`](docs/getting-started/README.md).
-- **Vận hành / chủ sở hữu triển khai**: ưu tiên [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md) và [`docs/ops/troubleshooting.md`](docs/ops/troubleshooting.md).
-- **Tích hợp / phát triển mở rộng**: ưu tiên [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md), [`docs/reference/api/config-reference.md`](docs/reference/api/config-reference.md), [`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md), [`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md).
+- **Người dùng mới / lần đầu trải nghiệm**: bắt đầu từ [`START_HERE.md`](START_HERE.md), sau đó đọc [`docs/getting-started/README.md`](docs/getting-started/README.md), sau đó [`docs/troubleshooting.md`](docs/troubleshooting.md).
+- **Vận hành / chủ sở hữu triển khai**: ưu tiên [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md), [`docs/ops/network-deployment.md`](docs/ops/network-deployment.md), [`docs/security/README.md`](docs/security/README.md).
+- **Tích hợp / phát triển mở rộng**: ưu tiên [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md), [`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md), [`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md).

--- a/README.vi.md
+++ b/README.vi.md
@@ -30,3 +30,23 @@ python rain_lab.py
 ```
 
 Xem thêm tài liệu lệnh và cấu hình trong docs hub và các trang tham chiếu runtime.
+
+## Năng lực tổng quan (Capabilities At A Glance)
+
+Trang này là điểm vào. Để xem đầy đủ bề mặt runtime (lệnh, kênh, provider, vận hành, bảo mật, phần cứng), dùng các liên kết bên dưới.
+
+| Nhóm năng lực | Bạn nhận được gì | Tài liệu chuẩn |
+| --- | --- | --- |
+| CLI và tự động hóa | Onboarding, agent, gateway/daemon, service, chẩn đoán, estop, cron, skills, cập nhật | [Commands Reference](docs/reference/cli/commands-reference.md) |
+| Kênh và nhắn tin | Phân phối đa kênh, allowlist, chế độ webhook/polling, cấu hình theo kênh | [Channels Reference](docs/reference/api/channels-reference.md) |
+| Provider và định tuyến mô hình | Provider local/cloud, alias, biến môi trường xác thực, quy trình làm mới mô hình | [Providers Reference](docs/reference/api/providers-reference.md) |
+| Cấu hình và hợp đồng runtime | Schema cấu hình và cam kết hành vi | [Config Reference](docs/reference/api/config-reference.md) |
+| Vận hành và xử lý sự cố | Runbook, mẫu triển khai, chẩn đoán và khôi phục lỗi | [Operations Runbook](docs/ops/operations-runbook.md), [Troubleshooting](docs/ops/troubleshooting.md) |
+| Mô hình bảo mật | Sandbox, ranh giới chính sách, tư thế kiểm toán | [Security Docs Hub](docs/security/README.md) |
+| Phần cứng và thiết bị ngoại vi | Thiết lập board và thiết kế công cụ ngoại vi | [Hardware Docs Hub](docs/hardware/README.md) |
+
+## Ai nên đọc gì tiếp theo (Who Should Read What Next)
+
+- **Người dùng mới / lần đầu trải nghiệm**: bắt đầu từ [`START_HERE.md`](START_HERE.md), sau đó đọc [`docs/getting-started/README.md`](docs/getting-started/README.md).
+- **Vận hành / chủ sở hữu triển khai**: ưu tiên [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md) và [`docs/ops/troubleshooting.md`](docs/ops/troubleshooting.md).
+- **Tích hợp / phát triển mở rộng**: ưu tiên [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md), [`docs/reference/api/config-reference.md`](docs/reference/api/config-reference.md), [`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md), [`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,3 +30,23 @@ python rain_lab.py
 ```
 
 更多命令与配置说明请参考文档中心与运行时参考文档。
+
+## 能力速览（Capabilities At A Glance）
+
+本页是入口。完整运行时能力（命令、通道、Provider、运维、安全、硬件）请参考下表链接。
+
+| 能力领域 | 你可以获得什么 | 规范文档 |
+| --- | --- | --- |
+| CLI 与自动化 | 引导、agent、gateway/daemon、service、诊断、estop、cron、skills、更新 | [Commands Reference](docs/reference/cli/commands-reference.md) |
+| 通道与消息 | 多通道投递、allowlist、webhook/polling 模式、按通道配置 | [Channels Reference](docs/reference/api/channels-reference.md) |
+| Provider 与模型路由 | 本地/云 Provider、别名、认证环境变量、模型刷新流程 | [Providers Reference](docs/reference/api/providers-reference.md) |
+| 配置与运行时契约 | 配置结构与行为保证 | [Config Reference](docs/reference/api/config-reference.md) |
+| 运维与故障排查 | Runbook、部署模式、诊断与故障恢复 | [Operations Runbook](docs/ops/operations-runbook.md), [Troubleshooting](docs/ops/troubleshooting.md) |
+| 安全模型 | 沙箱、策略边界、审计姿态 | [Security Docs Hub](docs/security/README.md) |
+| 硬件与外设 | 开发板接入与外设工具设计 | [Hardware Docs Hub](docs/hardware/README.md) |
+
+## 我应该先读什么（Who Should Read What Next）
+
+- **新用户 / 首次体验**：从 [`START_HERE.md`](START_HERE.md) 开始，然后阅读 [`docs/getting-started/README.md`](docs/getting-started/README.md)。
+- **运维 / 部署负责人**：优先阅读 [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md) 与 [`docs/ops/troubleshooting.md`](docs/ops/troubleshooting.md)。
+- **集成方 / 二次开发者**：优先阅读 [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md)、[`docs/reference/api/config-reference.md`](docs/reference/api/config-reference.md)、[`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md)、[`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,6 +47,6 @@ python rain_lab.py
 
 ## 我应该先读什么（Who Should Read What Next）
 
-- **新用户 / 首次体验**：从 [`START_HERE.md`](START_HERE.md) 开始，然后阅读 [`docs/getting-started/README.md`](docs/getting-started/README.md)。
-- **运维 / 部署负责人**：优先阅读 [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md) 与 [`docs/ops/troubleshooting.md`](docs/ops/troubleshooting.md)。
-- **集成方 / 二次开发者**：优先阅读 [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md)、[`docs/reference/api/config-reference.md`](docs/reference/api/config-reference.md)、[`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md)、[`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md)。
+- **新用户 / 首次体验**：从 [`START_HERE.md`](START_HERE.md) 开始，然后阅读 [`docs/getting-started/README.md`](docs/getting-started/README.md)，然后 [`docs/troubleshooting.md`](docs/troubleshooting.md)。
+- **运维 / 部署负责人**：优先阅读 [`docs/ops/operations-runbook.md`](docs/ops/operations-runbook.md)、[`docs/ops/network-deployment.md`](docs/ops/network-deployment.md)、[`docs/security/README.md`](docs/security/README.md)。
+- **集成方 / 二次开发者**：优先阅读 [`docs/reference/cli/commands-reference.md`](docs/reference/cli/commands-reference.md)、[`docs/reference/api/providers-reference.md`](docs/reference/api/providers-reference.md)、[`docs/reference/api/channels-reference.md`](docs/reference/api/channels-reference.md)。


### PR DESCRIPTION
### Motivation
- Improve the README front page by giving a concise capabilities overview and clear next-reading paths so users, operators, and integrators can quickly find relevant documentation.

### Description
- Added a new `Capabilities At A Glance` section with a capability-area table linking to canonical reference docs. 
- Added a `Who Should Read What Next` section outlining recommended doc flows for new users, operators, and integrators.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c46462482c8323a338553e5cf443d8)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
