### PR TITLE
docs(readme): clarify README scope and link full references

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ On macOS/Linux, `./install.sh` is the equivalent one-click repo installer.
 - Structured reasoning: R.A.I.N. Lab can debate, compare, and resolve disagreements instead of just generating plausible text.
 - Shareable outputs: beginner and demo sessions end in polished artifacts people can screenshot, revisit, and pass around.
 
+## README Scope
+
+This README is the product quickstart, not the full contract surface.
+For complete behavior and extension coverage, use the reference docs:
+
+- [Commands Reference](docs/reference/cli/commands-reference.md)
+- [Providers Reference](docs/reference/api/providers-reference.md)
+- [Channels Reference](docs/reference/api/channels-reference.md)
+- [Configuration Reference](docs/reference/config/config-reference.md)
+- [Operations Runbook](docs/operations/operations-runbook.md)
+
 ## Pick A Path
 
 | Goal | Run this |


### PR DESCRIPTION
### Motivation

- Clarify that `README.md` is intended as a quickstart/product overview and not the exhaustive contract for the project, and to direct readers to the full reference documents so they can discover complete behavior and extension points.

### Description

- Add a `README Scope` section to `README.md` that explicitly states the README is the quickstart surface and adds direct links to the canonical reference docs: `docs/reference/cli/commands-reference.md`, `docs/reference/api/providers-reference.md`, `docs/reference/api/channels-reference.md`, `docs/reference/config/config-reference.md`, and `docs/operations/operations-runbook.md`.

### Testing

- Ran `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings`, both of which completed successfully.
- Ran `cargo test`, which executed unit and integration suites; unit tests passed but the test run failed due to 10 failing integration tests in the Telegram-related groups (`integration::telegram_attachment_fallback::*` and `integration::telegram_finalize_draft::*`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c49452ff348323907d4840e7e50136)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
