### PR TITLE
fix(installer): remove unverified remote uv script execution

### DIFF
--- a/docs/one-click-bootstrap.md
+++ b/docs/one-click-bootstrap.md
@@ -29,7 +29,7 @@ Use the one-click repo installer:
 ./install.sh
 ```
 
-Under the hood, `install.sh` installs `uv` if needed, creates `.venv`, compiles and syncs the pinned requirements, runs `bootstrap_local.py`, and then hands off to James unless you pass `--no-greet`.
+Under the hood, `install.sh` requires `uv` to be pre-installed (see <https://docs.astral.sh/uv/getting-started/installation/>), creates `.venv`, compiles and syncs the pinned requirements, runs `bootstrap_local.py`, and then hands off to James unless you pass `--no-greet`.
 
 ## After Install
 

--- a/docs/setup-guides/one-click-bootstrap.md
+++ b/docs/setup-guides/one-click-bootstrap.md
@@ -22,7 +22,7 @@ Run the root installer:
 ./install.sh
 ```
 
-That installer installs `uv` if needed, creates `.venv`, syncs the pinned Python requirements, runs `bootstrap_local.py`, and then opens the James handoff unless you pass `--no-greet`.
+That installer requires `uv` to be pre-installed (see <https://docs.astral.sh/uv/getting-started/installation/>), creates `.venv`, syncs the pinned Python requirements, runs `bootstrap_local.py`, and then opens the James handoff unless you pass `--no-greet`.
 
 ## After Install
 

--- a/install.sh
+++ b/install.sh
@@ -78,19 +78,7 @@ resolve_uv_path() {
 }
 
 install_uv() {
-  local installer_path
-
-  if ! command -v curl >/dev/null 2>&1; then
-    fail "curl is required to install uv"
-  fi
-
-  installer_path="$(mktemp -t rain-install-uv.XXXXXX.sh)"
-
-  info "Downloading uv installer"
-  curl -LsSf "https://astral.sh/uv/install.sh" -o "$installer_path"
-  sh "$installer_path"
-  rm -f "$installer_path"
-  export PATH="$HOME/.local/bin:$PATH"
+  fail "uv is required but was not found. Please install uv first (https://docs.astral.sh/uv/getting-started/installation/) and re-run install.sh"
 }
 
 ensure_uv() {

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ Usage:
   ./install.sh [options]
 
 This installer mirrors the Windows INSTALL_RAIN.cmd flow:
-1. install uv (via curl) if missing
+1. verify uv is installed (see https://docs.astral.sh/uv/getting-started/installation/)
 2. create .venv with Python 3.12
 3. compile and sync pinned dependencies
 4. run bootstrap_local.py to fetch the prebuilt runtime and initialize config
@@ -89,13 +89,6 @@ ensure_uv() {
   fi
 
   install_uv
-
-  if uv_path="$(resolve_uv_path)"; then
-    printf '%s\n' "$uv_path"
-    return 0
-  fi
-
-  fail "uv installation completed but the uv executable was not found"
 }
 
 run_uv() {

--- a/install.sh
+++ b/install.sh
@@ -15,8 +15,8 @@ R.A.I.N. Lab local installer (macOS/Linux)
 Usage:
   ./install.sh [options]
 
-This installer mirrors the Windows INSTALL_RAIN.cmd flow:
-1. verify uv is installed (see https://docs.astral.sh/uv/getting-started/installation/)
+This installer performs the following steps:
+1. verify uv is pre-installed (see https://docs.astral.sh/uv/getting-started/installation/)
 2. create .venv with Python 3.12
 3. compile and sync pinned dependencies
 4. run bootstrap_local.py to fetch the prebuilt runtime and initialize config

--- a/tests/test_posix_one_click_install.py
+++ b/tests/test_posix_one_click_install.py
@@ -11,6 +11,7 @@ def test_posix_installer_uses_fetch_first_flow(repo_root: Path) -> None:
     assert "chat_with_james.py" in text
     assert "--greet" in text
     assert "requirements-pinned.txt" in text
-    assert '"https://astral.sh/uv/install.sh"' in text
+    assert "https://docs.astral.sh/uv/getting-started/installation/" in text
+    assert '"https://astral.sh/uv/install.sh"' not in text
     assert "cargo build --release" not in text
     assert "cargo install --path" not in text


### PR DESCRIPTION
### Motivation
- The POSIX installer previously downloaded and executed `https://astral.sh/uv/install.sh` with no checksum or signature verification, creating a supply‑chain/MITM RCE risk that must be eliminated.

### Description
- Replace the `install_uv()` implementation to fail fast and instruct users to install `uv` via `https://docs.astral.sh/uv/getting-started/installation/` instead of fetching and executing a remote script, and update `tests/test_posix_one_click_install.py` to assert the documentation URL is present and the insecure `astral.sh` installer URL is absent.

### Testing
- Ran `cargo fmt --all -- --check`, `bash -n install.sh`, and `pytest -q tests/test_posix_one_click_install.py`; all checks passed (tests: 2 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c461597a108323a69b3e26827763a5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
