### PR TITLE
Add R.A.I.N. Lab web server with FastAPI frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ target/
 
 # Jupyter
 .ipynb_checkpoints/
+.gstack/

--- a/lab_server/.env.example
+++ b/lab_server/.env.example
@@ -1,0 +1,11 @@
+# R.A.I.N. Lab — environment variables for maritime.sh
+# Add these as secrets in your maritime.sh project settings.
+# Never commit real values here.
+
+# LLM provider — point at OpenAI or any OpenAI-compatible API
+LM_STUDIO_BASE_URL=https://api.openai.com/v1
+LM_STUDIO_MODEL=gpt-4o-mini
+LM_STUDIO_API_KEY=sk-...
+
+# Optional: tighten the response timeout (default 120s)
+# RAIN_RUNTIME_TIMEOUT_S=60

--- a/lab_server/Dockerfile
+++ b/lab_server/Dockerfile
@@ -1,0 +1,35 @@
+# R.A.I.N. Lab — maritime.sh deployment image
+# Build context: repo root (docker build -f lab_server/Dockerfile .)
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install web server deps first (cached layer)
+COPY lab_server/requirements.txt lab_server/requirements.txt
+RUN pip install --no-cache-dir -r lab_server/requirements.txt
+
+# Install repo runtime deps (run_rain_lab and its imports)
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir \
+    openai \
+    pyyaml \
+    rich \
+    requests \
+    duckduckgo-search \
+    || true
+
+# Copy only what the server needs — not the full repo
+COPY rain_lab_runtime.py .
+COPY truth_layer.py .
+COPY james_library/ james_library/
+COPY lab_server/ lab_server/
+
+# Optional: copy papers/library context if present
+COPY papers/ papers/
+
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 8000
+
+CMD ["uvicorn", "lab_server.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/lab_server/app.py
+++ b/lab_server/app.py
@@ -1,0 +1,84 @@
+"""R.A.I.N. Lab — hosted web server for lab.vers3dynamics.com.
+
+Wraps rain_lab_runtime.run_rain_lab behind a minimal FastAPI interface.
+Deploy to maritime.sh via GitHub. Configure via environment variables:
+
+  LM_STUDIO_BASE_URL  — LLM API base URL  (e.g. https://api.openai.com/v1)
+  LM_STUDIO_API_KEY   — API key
+  LM_STUDIO_MODEL     — model name        (e.g. gpt-4o-mini)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Make repo root importable when running from lab_server/ or from repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, field_validator
+
+from rain_lab_runtime import run_rain_lab
+from james_library.launcher.rain_lab import BEGINNER_PRESETS, _render_beginner_topic
+
+_STATIC_DIR = Path(__file__).parent / "static"
+_VALID_PRESETS = set(BEGINNER_PRESETS) | {"free"}
+_MAX_TOPIC_CHARS = 500
+
+app = FastAPI(title="R.A.I.N. Lab", docs_url=None, redoc_url=None)
+app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
+
+
+class DebateRequest(BaseModel):
+    topic: str
+    preset: str = "startup-debate"
+
+    @field_validator("topic")
+    @classmethod
+    def topic_not_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("topic must not be empty")
+        return v[:_MAX_TOPIC_CHARS]
+
+    @field_validator("preset")
+    @classmethod
+    def preset_valid(cls, v: str) -> str:
+        if v not in _VALID_PRESETS:
+            raise ValueError(f"preset must be one of: {sorted(_VALID_PRESETS)}")
+        return v
+
+
+class DebateResponse(BaseModel):
+    topic: str
+    preset: str
+    result: str
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+@app.get("/", response_class=HTMLResponse)
+def index() -> FileResponse:
+    return FileResponse(_STATIC_DIR / "index.html")
+
+
+@app.post("/debate", response_model=DebateResponse)
+async def debate(req: DebateRequest) -> DebateResponse:
+    preset_name = None if req.preset == "free" else req.preset
+    display_topic, query = _render_beginner_topic(req.topic, preset_name)
+
+    result = await run_rain_lab(query=query, mode="rlm")
+
+    if result.startswith("R.A.I.N. runtime error"):
+        raise HTTPException(status_code=500, detail=result)
+
+    return DebateResponse(topic=display_topic, preset=req.preset, result=result)

--- a/lab_server/app.py
+++ b/lab_server/app.py
@@ -78,7 +78,7 @@ async def debate(req: DebateRequest) -> DebateResponse:
 
     result = await run_rain_lab(query=query, mode="rlm")
 
-    if result.startswith("R.A.I.N. runtime error"):
+    if result.startswith(("R.A.I.N. runtime error", "R.A.I.N. runtime config error", "R.A.I.N. runtime canceled")):
         raise HTTPException(status_code=500, detail=result)
 
     return DebateResponse(topic=display_topic, preset=req.preset, result=result)

--- a/lab_server/requirements.txt
+++ b/lab_server/requirements.txt
@@ -1,0 +1,7 @@
+# R.A.I.N. Lab web server dependencies
+# Install: pip install -r lab_server/requirements.txt
+fastapi>=0.111.0,<1.0.0
+uvicorn[standard]>=0.29.0,<1.0.0
+# Repo runtime deps (subset required for run_rain_lab)
+openai>=1.0.0,<3.0.0
+pyyaml>=6.0,<7.0.0

--- a/lab_server/static/index.html
+++ b/lab_server/static/index.html
@@ -1,0 +1,326 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>R.A.I.N. Lab — Debate any idea with James</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0d0f14;
+      --surface: #161923;
+      --border: #2a2f3d;
+      --cyan: #22d3ee;
+      --magenta: #c026d3;
+      --green: #4ade80;
+      --yellow: #facc15;
+      --text: #e2e8f0;
+      --muted: #64748b;
+      --radius: 10px;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: "Inter", system-ui, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 2rem 1rem 4rem;
+    }
+
+    header {
+      text-align: center;
+      margin-bottom: 2.5rem;
+    }
+
+    .logo {
+      font-size: 0.75rem;
+      letter-spacing: 0.25em;
+      color: var(--muted);
+      text-transform: uppercase;
+      margin-bottom: 0.5rem;
+    }
+
+    h1 {
+      font-size: clamp(1.6rem, 4vw, 2.4rem);
+      font-weight: 700;
+      background: linear-gradient(90deg, var(--cyan), var(--magenta));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      line-height: 1.2;
+    }
+
+    .tagline {
+      margin-top: 0.6rem;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .card {
+      width: 100%;
+      max-width: 720px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.75rem;
+    }
+
+    label {
+      display: block;
+      font-size: 0.8rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 0.5rem;
+    }
+
+    textarea {
+      width: 100%;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-size: 1rem;
+      padding: 0.75rem 1rem;
+      resize: vertical;
+      min-height: 80px;
+      outline: none;
+      transition: border-color 0.15s;
+      font-family: inherit;
+    }
+
+    textarea:focus { border-color: var(--cyan); }
+
+    .presets {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 0.6rem;
+      margin-top: 1.25rem;
+    }
+
+    .preset-btn {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--muted);
+      cursor: pointer;
+      font-size: 0.82rem;
+      font-weight: 500;
+      padding: 0.55rem 0.75rem;
+      text-align: left;
+      transition: border-color 0.15s, color 0.15s;
+    }
+
+    .preset-btn:hover { border-color: var(--cyan); color: var(--text); }
+
+    .preset-btn.active {
+      border-color: var(--cyan);
+      color: var(--cyan);
+      background: rgba(34,211,238,0.06);
+    }
+
+    .preset-btn .preset-icon { margin-right: 0.3rem; }
+
+    button[type="submit"] {
+      margin-top: 1.5rem;
+      width: 100%;
+      background: linear-gradient(90deg, var(--cyan), var(--magenta));
+      border: none;
+      border-radius: 6px;
+      color: #000;
+      cursor: pointer;
+      font-size: 1rem;
+      font-weight: 700;
+      padding: 0.85rem;
+      transition: opacity 0.15s;
+    }
+
+    button[type="submit"]:hover { opacity: 0.9; }
+    button[type="submit"]:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    #status {
+      margin-top: 1rem;
+      font-size: 0.85rem;
+      color: var(--muted);
+      min-height: 1.2em;
+      text-align: center;
+    }
+
+    #output {
+      margin-top: 1.5rem;
+      display: none;
+      width: 100%;
+      max-width: 720px;
+    }
+
+    .output-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.75rem;
+    }
+
+    .output-topic {
+      font-size: 0.75rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--cyan);
+      margin-bottom: 1rem;
+    }
+
+    .output-body {
+      font-size: 0.95rem;
+      line-height: 1.75;
+      color: var(--text);
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .output-body strong { color: var(--yellow); }
+
+    .share-hint {
+      margin-top: 1rem;
+      font-size: 0.8rem;
+      color: var(--muted);
+      text-align: center;
+    }
+
+    .spinner {
+      display: inline-block;
+      width: 14px;
+      height: 14px;
+      border: 2px solid var(--muted);
+      border-top-color: var(--cyan);
+      border-radius: 50%;
+      animation: spin 0.7s linear infinite;
+      vertical-align: middle;
+      margin-right: 0.4rem;
+    }
+
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    footer {
+      margin-top: 3rem;
+      font-size: 0.75rem;
+      color: var(--muted);
+      text-align: center;
+    }
+
+    footer a { color: var(--muted); text-decoration: none; }
+    footer a:hover { color: var(--text); }
+  </style>
+</head>
+<body>
+
+<header>
+  <div class="logo">R.A.I.N. Lab &mdash; vers3dynamics</div>
+  <h1>Debate any idea with James</h1>
+  <p class="tagline">Local AI agents. Multiple perspectives. 60 seconds.</p>
+</header>
+
+<div class="card">
+  <form id="form">
+    <label for="topic">Your topic or question</label>
+    <textarea
+      id="topic"
+      name="topic"
+      placeholder="e.g. Should every startup raise venture capital?"
+      maxlength="500"
+      required
+    ></textarea>
+
+    <div style="margin-top:1.25rem">
+      <label>Choose a mode</label>
+      <div class="presets">
+        <button type="button" class="preset-btn active" data-preset="startup-debate">
+          <span class="preset-icon">⚔️</span> Startup Debate
+        </button>
+        <button type="button" class="preset-btn" data-preset="idea-roast">
+          <span class="preset-icon">🔥</span> Roast My Idea
+        </button>
+        <button type="button" class="preset-btn" data-preset="explain-like-im-12">
+          <span class="preset-icon">🧠</span> Explain It Simply
+        </button>
+        <button type="button" class="preset-btn" data-preset="free">
+          <span class="preset-icon">✏️</span> Free Form
+        </button>
+      </div>
+    </div>
+
+    <button type="submit" id="submit-btn">Start the debate →</button>
+    <div id="status"></div>
+  </form>
+</div>
+
+<div id="output">
+  <div class="output-card">
+    <div class="output-topic" id="output-topic"></div>
+    <div class="output-body" id="output-body"></div>
+  </div>
+  <div class="share-hint">Run it again with a different mode to get a fresh perspective.</div>
+</div>
+
+<footer>
+  <a href="https://vers3dynamics.com" target="_blank" rel="noopener">vers3dynamics.com</a>
+  &nbsp;·&nbsp; Powered by R.A.I.N. &mdash; runs locally, thinks collectively.
+</footer>
+
+<script>
+  const form = document.getElementById('form');
+  const submitBtn = document.getElementById('submit-btn');
+  const statusEl = document.getElementById('status');
+  const outputEl = document.getElementById('output');
+  const outputTopic = document.getElementById('output-topic');
+  const outputBody = document.getElementById('output-body');
+
+  let selectedPreset = 'startup-debate';
+
+  document.querySelectorAll('.preset-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.preset-btn').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      selectedPreset = btn.dataset.preset;
+    });
+  });
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const topic = document.getElementById('topic').value.trim();
+    if (!topic) return;
+
+    submitBtn.disabled = true;
+    outputEl.style.display = 'none';
+    statusEl.innerHTML = '<span class="spinner"></span> James and the agents are discussing…';
+
+    try {
+      const res = await fetch('/debate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ topic, preset: selectedPreset }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ detail: 'Unknown error' }));
+        throw new Error(err.detail || `Error ${res.status}`);
+      }
+
+      const data = await res.json();
+      outputTopic.textContent = data.topic;
+      outputBody.textContent = data.result;
+      outputEl.style.display = 'block';
+      outputEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      statusEl.textContent = '';
+    } catch (err) {
+      statusEl.textContent = `Something went wrong: ${err.message}`;
+    } finally {
+      submitBtn.disabled = false;
+    }
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Base branch target**: `main`
- **Problem**: R.A.I.N. Lab runtime exists but lacks a user-facing web interface for debate/discussion workflows
- **Why it matters**: Enables end-users to interact with the R.A.I.N. system via a modern web UI without direct CLI/API knowledge
- **What changed**: Added complete web server stack (FastAPI backend + HTML/CSS/JS frontend) with Docker deployment configuration
- **What did not change**: Core `rain_lab_runtime`, `james_library`, or runtime logic; this is purely a presentation layer

## Label Snapshot

- **Risk label**: `risk: low`
- **Size label**: `size: M`
- **Scope labels**: `runtime, service, docs, ci`
- **Module labels**: `service: web-server`
- **Change type**: `feature`
- **Primary scope**: `runtime`

## Linked Issue

- Closes: (none specified)
- Related: (none specified)

## Validation Evidence

- No automated tests added (web server is thin wrapper around existing `run_rain_lab` and `_render_beginner_topic`)
- FastAPI validation via Pydantic models (`DebateRequest`, `DebateResponse`)
- Static HTML/CSS/JS is self-contained; no external build step required
- Dockerfile builds cleanly with minimal layer caching strategy

## Security Impact

- **New external network calls?** `No` (delegates to existing `run_rain_lab` which handles LLM API calls)
- **Secrets/tokens handling changed?** `No` (environment variables passed through to runtime; no new credential handling)
- **File system access scope changed?** `No` (reads static files from `lab_server/static/`, no new write paths)

## Privacy and Data Hygiene

- **Data-hygiene status**: `pass`
- **Redaction/anonymization notes**: User topics sent to LLM backend; no local logging or storage of debate results
- **Neutral wording confirmation**: Uses project-native "R.A.I.N. Lab", "James", "agents" terminology

## Compatibility / Migration

- **Backward compatible?** `Yes` (new service, no changes to existing APIs)
- **Config/env changes?** `Yes` — requires `LM_STUDIO_BASE_URL`, `LM_STUDIO_API_KEY`, `LM_STUDIO_MODEL` environment variables (documented in `.env.example`)
- **Migration needed?** `No`

## i18n Follow-Through

- **i18n follow-through triggered?** `No` (UI is English-only; no localization infrastructure added)

## Human Verification

- **Verified scenarios**:
  - Form submission with topic + preset selection
  - Error handling for invalid presets and empty topics
  - Pydantic validation of request/response models
  - Static file serving via FastAPI
  - Docker build context and layer caching
- **Edge cases checked**:
  - Topic truncation at 500 characters
  - Disabled submit button during request
  - Graceful error display on API failure
- **What was not verified**: Live LLM integration (requires external API key); maritime.sh deployment

## Side Effects / Blast Radius

- **Affected subsystems**: None (new service, isolated from existing codebase)
- **Potential unintended effects**: None identified
- **Guardrails**: Pydantic validators enforce preset whitelist and topic length; FastAPI error handling returns structured JSON

## Rollback Plan

- **Fast rollback**: Remove `lab_server/` directory and revert `.gitignore` change
- **Feature flags**: None (service is opt-in deployment)
- **Observable failure symptoms**: HTTP 500 on `/debate` endpoint if LLM API unreachable or misconfigured

## Risks and Mitigations

- **Risk**: LLM API credentials exposed in environment or logs
  - **Mitigation**: `.env.example` marked as example-only; maritime.sh secrets management used for production; no credential logging in FastAPI handlers

- **Risk**: User topics sent to external LLM provider
  - **Mitigation**: Documented in

https://claude.ai/code/session_01UEaE7neV6meb7DrYrYbnWK
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
