### PR TITLE
feat(web): add top security announcement banner

### DIFF
--- a/web/src/components/SecurityBanner.tsx
+++ b/web/src/components/SecurityBanner.tsx
@@ -1,0 +1,27 @@
+import { ArrowRight, ShieldCheck } from 'lucide-react';
+
+export default function SecurityBanner() {
+  return (
+    <div className="w-full bg-emerald-950/30 border-b border-emerald-900/50 backdrop-blur-md relative z-[100] animate-fade-in">
+      <div className="max-w-7xl mx-auto px-4 py-2.5 sm:px-6 lg:px-8 flex flex-col sm:flex-row items-center justify-center gap-2 text-sm">
+        <div className="flex items-center gap-2 text-zinc-200">
+          <ShieldCheck className="w-4 h-4 text-emerald-400 shrink-0" />
+          <span className="text-center sm:text-left">
+            <span className="font-semibold text-white tracking-wide">100% Open Source.</span>{' '}
+            Local-by-default. Sandboxed execution.
+          </span>
+        </div>
+
+        <a
+          href="https://github.com/topherchris420/james_library/blob/main/SECURITY.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group flex items-center gap-1 text-emerald-400 hover:text-emerald-300 font-medium transition-colors"
+        >
+          Read our Security Architecture on GitHub
+          <ArrowRight className="w-3.5 h-3.5 transition-transform group-hover:translate-x-1" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,4 +1,5 @@
 import { Outlet, useLocation } from 'react-router-dom';
+import SecurityBanner from '@/components/SecurityBanner';
 import Sidebar from '@/components/layout/Sidebar';
 import Header from '@/components/layout/Header';
 import { ErrorBoundary } from '@/App';
@@ -13,6 +14,7 @@ export default function Layout() {
 
       {/* Main area offset by sidebar width (240px / w-60) */}
       <div className="ml-60 flex flex-col flex-1 min-w-0 h-screen">
+        <SecurityBanner />
         <Header />
 
         {/* Page content — ErrorBoundary keyed by pathname so the nav shell


### PR DESCRIPTION
### Motivation
- Surface the project's security posture and provide an obvious link to `SECURITY.md` as a site-wide announcement bar. 
- Keep the banner visually consistent with the site's emerald/zinc aesthetic and use existing iconography and utilities. 
- Place the announcement above the header so it appears across all pages as a top announcement bar.

### Description
- Add a new component `web/src/components/SecurityBanner.tsx` which renders the emerald/zinc announcement with `ShieldCheck` and `ArrowRight` icons and a link to the repository `SECURITY.md` on GitHub. 
- Render the banner at the top of the app shell by importing and inserting `SecurityBanner` into `web/src/components/layout/Layout.tsx` above the `Header`. 
- Use the existing `animate-fade-in` CSS utility for the entrance animation instead of adding `framer-motion` to avoid introducing an unresolved dependency in this environment. 

### Testing
- Ran `cd web && npm run lint` and the lint step completed successfully. 
- Ran `cd web && npm test -- --run` and all tests passed (`4 files, 9 tests`). 
- Attempted to add `framer-motion` with `npm install framer-motion@^12.23.24`, but registry access returned HTTP 403 so the implementation avoids adding that dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c988bdbc80832390c41fd1001d052a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
