### PR TITLE
refactor: Format assert! macros in bench tests for consistency

### DIFF
--- a/crates/rain-bench/tests/bench_tests.rs
+++ b/crates/rain-bench/tests/bench_tests.rs
@@ -143,10 +143,16 @@ fn rain_bench_tempfile_cleanup() {
         // SqliteMemory creates the DB at <workspace>/memory/brain.db
         db_path = tmp.path().join("memory").join("brain.db");
         let _mem = SqliteMemory::new(tmp.path()).unwrap();
-        assert!(db_path.exists(), "memory/brain.db should exist while TempDir is alive");
+        assert!(
+            db_path.exists(),
+            "memory/brain.db should exist while TempDir is alive"
+        );
         // TempDir drops here
     }
-    assert!(!db_path.exists(), "memory/brain.db should be deleted after TempDir is dropped");
+    assert!(
+        !db_path.exists(),
+        "memory/brain.db should be deleted after TempDir is dropped"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -231,7 +237,10 @@ async fn rain_bench_empty_recall_returns_empty() {
         .recall("anything", 10, Some("empty_session"), None, None)
         .await
         .unwrap();
-    assert!(entries.is_empty(), "recall on empty DB should return empty vec");
+    assert!(
+        entries.is_empty(),
+        "recall on empty DB should return empty vec"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: Assert macro calls in `bench_tests.rs` have inconsistent formatting, with some multi-line assertions using inline message parameters
- Why it matters: Maintains consistent code style and readability across the test suite
- What changed: Reformatted three `assert!` macro invocations to split message parameters onto separate lines for improved readability
- What did **not** change: No functional changes; all assertions remain identical in behavior

## Label Snapshot

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `tests`
- Module labels: N/A
- Contributor tier label: Auto-managed
- If any auto-label is incorrect: None

## Change Metadata

- Change type: `chore`
- Primary scope: `tests`

## Linked Issue

- Closes: (none)
- Related: (none)

## Validation Evidence

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test --test bench_tests
```

- Evidence provided: Existing tests pass; formatting is now consistent with Rust conventions
- If any command is intentionally skipped: None

## Quality Delta

- Quality delta required: `No`
- Expected panic count impact: 0
- Expected unwrap count impact: 0
- Expected flaky test rate impact: 0
- Expected mean PR size impact: 0
- Expected critical-path test coverage impact: 0

## Security Impact

- New permissions/capabilities: `No`
- New external network calls: `No`
- Secrets/tokens handling changed: `No`
- File system access scope changed: `No`

## Privacy and Data Hygiene

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: N/A

## Compatibility / Migration

- Backward compatible: `Yes`
- Config/env changes: `No`
- Migration needed: `No`

## i18n Follow-Through

- i18n follow-through triggered: `No`

## Human Verification

What was personally validated beyond CI:

- Verified scenarios: Code formatting matches Rust style conventions; all assertions remain functionally identical
- Edge cases checked: N/A
- What was not verified: N/A (pure formatting change)

## Side Effects / Blast Radius

- Affected subsystems/workflows: Test suite only
- Potential unintended effects: None
- Guardrails/monitoring for early detection: N/A

## Rollback Plan

- Fast rollback command/path: `git revert <commit-hash>`
- Feature flags or config toggles: N/A
- Observable failure symptoms: N/A

## Risks and Mitigations

None

https://claude.ai/code/session_01XGgLQaEjPjP7kZkKp9qC2Z
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
