### PR TITLE
Refactor provider config: add MiniMax support, clarify API URL handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,15 @@ PROVIDER=openrouter
 # R.A.I.N._MODEL=anthropic/claude-sonnet-4-6
 # R.A.I.N._TEMPERATURE=0.7
 
+# ── Local Ollama ─────────────────────────────────────────────
+# To use a local Ollama instance, set provider to "ollama".
+# The default base URL is http://localhost:11434 — override with:
+# R.A.I.N._PROVIDER_URL=http://localhost:11434
+#
+# IMPORTANT: Do not use cloud model names (e.g. "minimax-m2.7:cloud")
+# with a local Ollama endpoint. For MiniMax cloud models, set
+# PROVIDER=minimax and supply MINIMAX_API_KEY instead.
+
 # Workspace directory override
 # R.A.I.N._WORKSPACE=/path/to/workspace
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,14 +10,14 @@
 api_key = "YOUR_API_KEY_HERE"
 
 # Provider configuration
-# Options: "openrouter", "ollama", "anthropic", "openai"
-default_provider = "ollama"
-default_model = "minimax-m2.7:cloud"
+# Options: "openrouter", "ollama", "anthropic", "openai", "minimax"
+default_provider = "minimax"
+default_model = "minimax-m2.7"
 default_temperature = 0.7
 
-# Remote Ollama endpoint for cloud models (required for ':cloud' suffix).
-# For local models, use api_url = "http://localhost:11434" instead.
-api_url = "https://ollama.com"
+# api_url is optional — each provider uses its own default endpoint.
+# Uncomment to override (e.g. for local Ollama):
+# api_url = "http://localhost:11434"
 
 # =============================================================================
 # Environment Variables (optional overrides)

--- a/dev/config.template.toml
+++ b/dev/config.template.toml
@@ -1,9 +1,10 @@
 workspace_dir = "/R.A.I.N.-data/workspace"
 config_path = "/R.A.I.N.-data/.R.A.I.N./config.toml"
-# This is the Ollama Base URL, not a secret key
-api_key = "http://host.docker.internal:11434"
+# For Ollama, use "ollama" as the dummy key; set the URL via api_url.
+api_key = "ollama"
+api_url = "http://host.docker.internal:11434"
 default_provider = "ollama"
-default_model = "minimax-m2.7:cloud"
+default_model = "llama3"
 default_temperature = 0.7
 
 [gateway]


### PR DESCRIPTION
## Summary

- **Base branch target:** `main`
- **Problem:** Configuration examples were misleading about API URL requirements and cloud model handling; MiniMax provider was not listed as an option despite being used in examples.
- **Why it matters:** Users attempting to configure local Ollama or cloud providers (especially MiniMax) were getting conflicting guidance, leading to misconfiguration and support friction.
- **What changed:** 
  - Added `"minimax"` to provider options in config examples
  - Changed default provider from `ollama` with cloud model suffix to `minimax` with proper model name
  - Clarified that `api_url` is optional and provider-specific, with examples for local Ollama override
  - Added explicit guidance in `.env.example` distinguishing local Ollama setup from MiniMax cloud models
  - Updated dev template to use local Ollama correctly (dummy key + explicit URL)
- **What did not change:** Core provider implementation, runtime behavior, or API contracts

## Label Snapshot

- **Risk label:** `risk: low`
- **Size label:** `size: S`
- **Scope labels:** `config`, `provider`, `docs`
- **Module labels:** `provider: minimax`, `provider: ollama`
- **Contributor tier label:** (auto-managed)
- **Auto-label corrections:** None

## Change Metadata

- **Change type:** `docs` + `chore`
- **Primary scope:** `provider`

## Linked Issue

- Closes: (none specified)
- Related: (none specified)

## Validation Evidence

No code logic changes; configuration examples only.

```bash
# Configuration files are TOML/ENV examples — no compilation/test impact
# Manual verification: TOML syntax valid, environment variable names consistent
```

- **Evidence provided:** Configuration files are syntactically valid TOML and shell-compatible ENV format
- **Intentionally skipped:** `cargo test` — no Rust code changed

## Quality Delta

- **Quality delta required?** `No` — configuration-only changes with no runtime impact

## Security Impact

- **New permissions/capabilities?** `No`
- **New external network calls?** `No`
- **Secrets/tokens handling changed?** `No` — guidance clarified but no new secret handling
- **File system access scope changed?** `No`

## Privacy and Data Hygiene

- **Data-hygiene status:** `pass`
- **Redaction/anonymization notes:** None
- **Neutral wording confirmation:** Uses project-native provider names (`minimax`, `ollama`, `openai`, `anthropic`, `openrouter`)

## Compatibility / Migration

- **Backward compatible?** `Yes` — existing configs continue to work; changes are to example/template files only
- **Config/env changes?** `Yes` — examples updated to reflect best practices
- **Migration needed?** `No` — users can adopt new patterns at their own pace
- **Upgrade steps:** N/A (examples only)

## i18n Follow-Through

- **i18n follow-through triggered?** `No` — configuration examples are language-agnostic
- **Localized docs impact:** None

## Human Verification

- **Verified scenarios:**
  - TOML syntax correctness in `config.example.toml` and `dev/config.template.toml`
  - ENV variable naming consistency in `.env.example`
  - Clarity of guidance for local Ollama vs. MiniMax cloud setup
- **Edge cases checked:** Comments correctly distinguish optional vs. required fields
- **What was not verified:** Runtime behavior (no code changes)

## Side Effects / Blast Radius

- **Affected subsystems/workflows:** Configuration initialization, provider selection documentation
- **Potential unintended effects:** None — examples are non-binding
- **Guardrails/monitoring:** Users following updated examples will have clearer setup paths

## Rollback Plan

- **Fast rollback command/path:** `git revert <commit-hash>` (restores original example files)
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** None expected (examples only)

## Risks and Mitigations

- **Risk:** Users with existing configs using `oll

https://claude.ai/code/session_01PjeuGt5cEGur9uM8joCucC
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
