### PR TITLE
Remove automatic browser opening functionality from rain_lab launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Beginner and demo runs generate:
 - a matching poster SVG
 - a local showcase page with poster previews and follow-up commands
 
-Use `python rain_lab.py --open-browser off` if you want to keep everything local without auto-opening pages.
 On Windows, `INSTALL_RAIN.cmd` also creates desktop and Start Menu shortcuts.
 On macOS/Linux, `./install.sh` is the equivalent of a one-click repo installer.
 

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -15,7 +15,7 @@ python rain_lab.py
 ```
 
 For non-technical users, this is the **only daily entry point you need**. The script opens a guided wizard, pressing Enter starts the no-setup instant demo, and every beginner/demo run updates a local showcase page in `meeting_archives/RAIN_LAB_SHOWCASE.html`.
-Those runs also generate a screenshot-friendly HTML share card plus a matching poster SVG in `meeting_archives/`, and interactive runs can open them automatically. Use `--open-browser off` if you want to suppress that behavior.
+Those runs also generate a screenshot-friendly HTML share card plus a matching poster SVG in `meeting_archives/`.
 
 Windows users should start with `.\INSTALL_RAIN.cmd`. macOS/Linux users should start with `./install.sh`.
 
@@ -97,7 +97,6 @@ That's it. Just run that command, press Enter for the instant demo if you want t
 | **I'm not sure where to start** | `python rain_lab.py` (starts wizard) |
 | **Give it one idea and let it choose for me** | `python rain_lab.py --mode beginner --topic "your idea"` |
 | **Try a no-setup instant demo** | `python rain_lab.py --mode demo --preset startup-debate` |
-| **Keep everything local without opening pages** | `python rain_lab.py --open-browser off` |
 | Chat with AI about my research | `python rain_lab.py --mode chat --topic "your topic"` |
 | Check if my system is ready | `python rain_lab.py --mode validate` |
 | See what AI models are available | `python rain_lab.py --mode models` |

--- a/james_library/launcher/rain_lab.py
+++ b/james_library/launcher/rain_lab.py
@@ -28,7 +28,6 @@ import shutil
 import subprocess
 import sys
 import time
-import webbrowser
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from html import escape as html_escape
@@ -61,7 +60,6 @@ ASCII_ART_LINES = [
 ]
 
 VALID_UI_MODES = {"auto", "on", "off"}
-VALID_BROWSER_MODES = {"auto", "on", "off"}
 BEGINNER_DEBATE_HINTS = (
     "debate",
     "argue",
@@ -430,39 +428,6 @@ def _build_beginner_poster_svg(
 """
 
 
-def _should_open_local_page(args: argparse.Namespace) -> bool:
-    preference = getattr(args, "open_browser", "auto")
-    if preference == "off":
-        return False
-    if preference == "on":
-        return True
-    if os.environ.get("CI") or os.environ.get("PYTEST_CURRENT_TEST"):
-        return False
-    stdin_tty = bool(getattr(sys.stdin, "isatty", lambda: False)())
-    stdout_tty = bool(getattr(sys.stdout, "isatty", lambda: False)())
-    return stdin_tty and stdout_tty
-
-
-def _maybe_open_local_page(
-    args: argparse.Namespace,
-    page_path: Path,
-    *,
-    label: str,
-    log_path: Path | None = None,
-) -> bool:
-    if not _should_open_local_page(args):
-        return False
-
-    try:
-        opened = bool(webbrowser.open(page_path.resolve().as_uri()))
-    except Exception as exc:
-        _append_launcher_event(log_path, "local_page_open_failed", label=label, path=str(page_path), error=str(exc))
-        return False
-
-    if opened:
-        print(f"{ANSI_DIM}Opened {label} in your browser.{ANSI_RESET}")
-        _append_launcher_event(log_path, "local_page_opened", label=label, path=str(page_path))
-    return opened
 
 
 def _build_follow_up_moves(topic: str | None, current_preset: str | None) -> list[FollowUpMove]:
@@ -2108,7 +2073,6 @@ def _run_demo_session(
         print(f"{ANSI_GREEN}Share card ready: {share_card_path}{ANSI_RESET}")
         showcase_path = _write_beginner_showcase_page(args, repo_root, latest_share_card=share_card_path)
         print(f"{ANSI_GREEN}Local showcase ready: {showcase_path}{ANSI_RESET}")
-        _maybe_open_local_page(args, share_card_path, label="share card", log_path=log_path)
         _print_follow_up_moves(getattr(args, "display_topic", args.topic), getattr(args, "preset", None))
         _append_launcher_event(
             log_path,
@@ -2131,9 +2095,6 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     default_ui_mode = os.environ.get("RAIN_UI_MODE", "off").strip().lower()
     if default_ui_mode not in VALID_UI_MODES:
         default_ui_mode = "off"
-    default_browser_mode = os.environ.get("RAIN_OPEN_BROWSER", "auto").strip().lower()
-    if default_browser_mode not in VALID_BROWSER_MODES:
-        default_browser_mode = "auto"
     default_restart_sidecars = _env_bool("RAIN_RESTART_SIDECARS", True)
 
     parser = argparse.ArgumentParser(description="Unified launcher for rain_lab_meeting modes")
@@ -2229,15 +2190,6 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         help=(
             "Chat/Godot UI behavior: auto launches avatars when available,"
             " on requires UI stack, off (default) forces CLI-only."
-        ),
-    )
-    parser.add_argument(
-        "--open-browser",
-        choices=sorted(VALID_BROWSER_MODES),
-        default=default_browser_mode,
-        help=(
-            "Beginner/demo UX: auto opens the generated local page when interactive,"
-            " on always tries, off never opens the browser."
         ),
     )
     parser.add_argument(
@@ -2777,7 +2729,6 @@ def main(argv: list[str] | None = None) -> int:
             f"or pick a path below.{ANSI_RESET}"
         )
         print(f"{ANSI_DIM}Local showcase: {showcase_path}{ANSI_RESET}\n")
-        _maybe_open_local_page(args, showcase_path, label="showcase")
 
         print("What would you like to do first?")
         print(f"  {ANSI_GREEN}1{ANSI_RESET} - Instant demo (recommended first step)")
@@ -3021,7 +2972,6 @@ def main(argv: list[str] | None = None) -> int:
             print(f"{ANSI_GREEN}Share card ready: {share_card_path}{ANSI_RESET}", flush=True)
             showcase_path = _write_beginner_showcase_page(args, repo_root, latest_share_card=share_card_path)
             print(f"{ANSI_GREEN}Local showcase ready: {showcase_path}{ANSI_RESET}", flush=True)
-            _maybe_open_local_page(args, share_card_path, label="share card", log_path=log_path)
             _print_follow_up_moves(getattr(args, "display_topic", args.topic), getattr(args, "preset", None))
             _append_launcher_event(
                 log_path,

--- a/tests/test_rain_lab_launcher.py
+++ b/tests/test_rain_lab_launcher.py
@@ -27,7 +27,6 @@ def test_parse_defaults():
     assert args.mode == "chat"
     assert args.topic is None
     assert args.ui == "off"
-    assert args.open_browser == "auto"
     assert args.restart_sidecars is True
     assert args.max_sidecar_restarts == 2
     assert args.sidecar_restart_backoff == 0.5
@@ -487,7 +486,6 @@ def test_main_without_args_defaults_to_demo(monkeypatch, repo_root):
     recorded: dict[str, str] = {}
 
     monkeypatch.setattr(rain_launcher, "_print_banner", lambda: None)
-    monkeypatch.setattr(rain_launcher, "_maybe_open_local_page", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(
         rain_launcher,
         "_write_beginner_showcase_page",


### PR DESCRIPTION
## Summary

- **Base branch target**: `main`
- **Problem**: The automatic browser opening feature (`--open-browser` flag and related logic) adds complexity without clear user benefit and creates platform-specific behavior that's difficult to maintain.
- **Why it matters**: Simplifies the launcher codebase by removing a feature that duplicates functionality users can achieve manually (opening generated HTML files), reducing maintenance burden and potential cross-platform issues.
- **What changed**: Removed `webbrowser` import, deleted `_should_open_local_page()` and `_maybe_open_local_page()` functions, removed `--open-browser` CLI argument and `VALID_BROWSER_MODES` constant, removed all calls to `_maybe_open_local_page()` in demo and beginner flows, updated documentation to reflect removal.
- **What did not change**: Core demo/beginner functionality, showcase page generation, share card generation, or any other launcher features remain intact.

## Label Snapshot

- **Risk label**: `risk: low`
- **Size label**: `size: S`
- **Scope labels**: `scripts`
- **Module labels**: N/A
- **Contributor tier label**: Auto-managed
- **If any auto-label is incorrect**: None noted

## Change Metadata

- **Change type**: `refactor`
- **Primary scope**: `scripts`

## Linked Issue

- Closes: (none specified in diff)
- Related: (none specified in diff)

## Validation Evidence

- Existing unit test `test_parse_defaults()` updated to remove assertion on removed `open_browser` attribute
- Mock for `_maybe_open_local_page()` removed from `test_main_without_args_defaults_to_demo()` since function no longer exists
- All removed code paths were conditional/optional (browser opening was never required for core functionality)
- No new test failures expected; removed functionality was optional user convenience feature

## Quality Delta

- **Quality delta required?**: No
- **Expected panic count impact**: 0 (removed code was defensive/optional)
- **Expected unwrap count impact**: 0
- **Expected flaky test rate impact**: 0 (no behavioral changes to core logic)
- **Expected mean PR size impact**: Negative (net removal of ~70 lines)
- **Expected critical-path test coverage impact**: 0 (removed feature was not critical path)

## Security Impact

- **New permissions/capabilities?**: No
- **New external network calls?**: No (actually removes potential network calls via `webbrowser` module)
- **Secrets/tokens handling changed?**: No
- **File system access scope changed?**: No

## Privacy and Data Hygiene

- **Data-hygiene status**: `pass`
- **Redaction/anonymization notes**: N/A
- **Neutral wording confirmation**: Documentation updated to remove references to automatic browser behavior

## Compatibility / Migration

- **Backward compatible?**: No (removes `--open-browser` CLI flag)
- **Config/env changes?**: Yes (removes `RAIN_OPEN_BROWSER` environment variable support)
- **Migration needed?**: No (feature was optional; users can manually open generated files)
- **If yes, exact upgrade steps**: N/A

## i18n Follow-Through

- **i18n follow-through triggered?**: No (only removes user-facing text, no new text added)

## Human Verification

- **Verified scenarios**: 
  - Removed functions are no longer called anywhere in codebase
  - CLI argument parsing no longer references removed flag
  - Documentation accurately reflects removal
- **Edge cases checked**: Environment variable `RAIN_OPEN_BROWSER` no longer processed
- **What was not verified**: Runtime behavior (covered by existing tests)

## Side Effects / Blast Radius

- **Affected subsystems/workflows**: Beginner mode and demo mode no longer auto-open browser windows
- **Potential unintended effects**: Users expecting automatic browser opening will need to manually open generated HTML files (minimal impact since files are clearly logged with paths)
- **Guardrails/monitoring for early detection**: None needed; this is a feature removal with clear user workaround

## Rollback Plan

- **Fast rollback command/path**: `git revert <commit-hash>`

https://claude.ai/code/session_012YEcCY26rtx8EEzG1udFRq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
