### PR TITLE
fix(installer): avoid compiling pip requirements into uv native lockfile

### DIFF
--- a/INSTALL_RAIN.ps1
+++ b/INSTALL_RAIN.ps1
@@ -110,8 +110,12 @@ function Ensure-UvLock {
     )
 
     $runtimeRequirements = Join-Path $repoRoot "requirements-pinned.txt"
-    $lockPath = Join-Path $repoRoot "uv.lock"
+    $lockPath = Join-Path $repoRoot ".uv-pip.lock"
+    if (Test-Path $lockPath) {
+        Remove-Item $lockPath -Force
+    }
     Invoke-Uv -UvPath $UvPath -Args @("pip", "compile", $runtimeRequirements, "-o", $lockPath)
+    return $lockPath
 }
 
 function Ensure-RainEnvironment {
@@ -129,8 +133,8 @@ function Ensure-RainEnvironment {
 
     Invoke-Uv -UvPath $UvPath -Args @("python", "install", "3.12")
     Invoke-Uv -UvPath $UvPath -Args @("venv", $venvDir, "--python", "3.12")
-    Ensure-UvLock -UvPath $UvPath
-    Invoke-Uv -UvPath $UvPath -Args @("pip", "sync", "--python", $venvPython, (Join-Path $repoRoot "uv.lock"))
+    $pipLockPath = Ensure-UvLock -UvPath $UvPath
+    Invoke-Uv -UvPath $UvPath -Args @("pip", "sync", "--python", $venvPython, $pipLockPath)
 
     return $venvPython
 }

--- a/install.sh
+++ b/install.sh
@@ -183,8 +183,10 @@ main() {
 
   run_uv "$uv_path" python install "$PYTHON_VERSION"
   run_uv "$uv_path" venv "$venv_dir" --python "$PYTHON_VERSION"
-  run_uv "$uv_path" pip compile "$REPO_ROOT/requirements-pinned.txt" -o "$REPO_ROOT/uv.lock"
-  run_uv "$uv_path" pip sync --python "$venv_python" "$REPO_ROOT/uv.lock"
+  local pip_lock_file="$REPO_ROOT/.uv-pip.lock"
+  rm -f "$pip_lock_file"
+  run_uv "$uv_path" pip compile "$REPO_ROOT/requirements-pinned.txt" -o "$pip_lock_file"
+  run_uv "$uv_path" pip sync --python "$venv_python" "$pip_lock_file"
   run_uv "$uv_path" run --python "$venv_python" "$REPO_ROOT/bootstrap_local.py" "${BOOTSTRAP_ARGS[@]}"
 
   if [[ "$SKIP_GREET" == false ]]; then


### PR DESCRIPTION
### Motivation
- The installer was invoking `uv pip compile ... -o uv.lock` but `uv.lock` in the repo is a uv-native TOML lockfile, not a pip requirements-format file, causing `uv pip compile` to fail when it encounters TOML (`no such comparison operator "=").
- Prevent installer corruption/parse errors by separating pip-compiled requirements from uv's native lockfile format.
- Keep installer behavior deterministic and safe across Windows and POSIX flows.

### Description
- Stop writing pip-compiled output into `uv.lock` and generate a dedicated pip lock file named `.uv-pip.lock` instead.
- Update Windows installer `INSTALL_RAIN.ps1` to create/remove `.uv-pip.lock`, return its path from `Ensure-UvLock`, and pass that path into `pip sync`.
- Update POSIX installer `install.sh` to use a local `pip_lock_file` (`.uv-pip.lock`), remove any old file before compiling, and pass it to `pip sync`.
- This change prevents `uv pip compile` from parsing uv-native TOML data and isolates pip lock lifecycle to the installer run.

### Testing
- Ran `cargo fmt --all -- --check` which succeeded.
- Ran `cargo clippy --all-targets -- -D warnings` which completed without blocking warnings.
- Validated shell installer syntax with `bash -n install.sh` which returned OK.
- Attempted `cargo test` in this environment but the run timed out (`timeout 120 cargo test -q` produced exit `124`), and `pwsh`-based parsing check could not run because `pwsh` was not available in the container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cabdc65ad883328630064b0883d264)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
