### PR TITLE
fix(memory): restore ResonanceBackend alias to unblock CI builds

### DIFF
--- a/src/memory/resonance.rs
+++ b/src/memory/resonance.rs
@@ -71,6 +71,9 @@ pub struct ResonanceMemory {
     mass_tokens_per_unit: f64,
 }
 
+/// Backward-compatible alias for older call sites.
+pub type ResonanceBackend = ResonanceMemory;
+
 impl ResonanceMemory {
     pub fn with_embedder(
         workspace_dir: &Path,


### PR DESCRIPTION
### Motivation
- CI builds were failing due to a missing `ResonanceBackend` symbol after the concrete type was renamed to `ResonanceMemory`, breaking existing imports/call sites and causing compilation errors.

### Description
- Reintroduced a backward-compatible `pub type ResonanceBackend = ResonanceMemory;` in `src/memory/resonance.rs` so existing call sites that import or use `ResonanceBackend` continue to compile without behavioral changes.

### Testing
- Ran `cargo fmt --all -- --check` which passed.
- Ran `cargo clippy --all-targets -- -D warnings` which passed.
- Ran `cargo test --lib` which passed (unit tests ran successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbfa4075388332861af47836cb3617)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
