### PR TITLE
fix(channels): format provider manager module

### DIFF
--- a/src/channels/provider/mod.rs
+++ b/src/channels/provider/mod.rs
@@ -13,11 +13,11 @@ use crate::channels::ChannelRouteSelection;
 use crate::channels::ModelCacheState;
 use crate::providers::{self, Provider};
 use anyhow::Context;
+use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::path::Path;
 use std::sync::Arc;
-use parking_lot::Mutex;
 
 // ============================================================================
 // Constants
@@ -125,9 +125,7 @@ impl ChannelProviderManager {
         }
 
         // Only return the default provider when there's no credential override
-        if api_key_override.is_none()
-            && provider_name == self.default_provider_name.as_str()
-        {
+        if api_key_override.is_none() && provider_name == self.default_provider_name.as_str() {
             return Ok(Arc::clone(&self.default_provider));
         }
 
@@ -160,7 +158,9 @@ impl ChannelProviderManager {
 
         // Cache the provider
         let mut cache = self.cache.lock();
-        let cached = cache.entry(cache_key).or_insert_with(|| Arc::clone(&provider));
+        let cached = cache
+            .entry(cache_key)
+            .or_insert_with(|| Arc::clone(&provider));
         Ok(Arc::clone(cached))
     }
 


### PR DESCRIPTION
### Motivation
- Fix CI lint failure caused by formatting differences in `src/channels/provider/mod.rs` so `cargo fmt --all -- --check` passes.

### Description
- Applied `rustfmt`-style formatting to `src/channels/provider/mod.rs` to normalize import ordering and line wrapping (moved `parking_lot::Mutex` import, collapsed a multi-line `if` and wrapped a chained `HashMap::entry(...).or_insert_with(...)`) with no behavioral changes.

### Testing
- Ran `cargo fmt --all -- --check` and it passed after the formatting changes.
- Ran `cargo clippy --all-targets -- -D warnings` and it passed.
- Ran `ruff check .` and it passed.
- Ran the targeted provider tests with `cargo test channels::provider -- --nocapture` and all provider tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccc60144108324b473d70f834f52c7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
