### PR TITLE
docs(project): add 2026-04-02 project rating snapshot

### DIFF
--- a/docs/project/project-rating-2026-04-02.md
+++ b/docs/project/project-rating-2026-04-02.md
@@ -1,0 +1,31 @@
+# Project Rating Snapshot (2026-04-02)
+
+## Overall Rating
+
+**8.8 / 10 — Strong engineering foundation with one test reliability gap to address.**
+
+## Why this rating
+
+### Strengths
+
+- Large, comprehensive automated test suite (4,699 total tests discovered in `cargo test`).
+- Strict lint policy via `cargo clippy --all-targets -- -D warnings` passes cleanly.
+- Formatting gate (`cargo fmt --all -- --check`) passes.
+- Clear modular architecture and trait-driven extension model across providers/channels/tools/memory/runtime/peripherals.
+
+### Main gap
+
+- One failing test in the current run indicates a reliability issue in an LSP integration path:
+  - `tools::lsp_client::tests::manager_supports_symbols_definitions_and_references`
+  - Failure reason: initialize timeout (`timeout_ms: 10000`).
+
+## Recommended next step
+
+1. Stabilize the LSP integration test by reducing environment sensitivity (startup timing/process readiness), or mark and isolate it if it is intentionally integration-heavy.
+2. Keep this test in focused CI reporting so regressions are visible without obscuring broader pass rates.
+
+## Validation commands run
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test`


### PR DESCRIPTION
### Motivation
- Capture a dated, reproducible project health snapshot (architecture strengths, CI gates, and a current reliability gap) so maintainers and reviewers have a concise baseline for prioritizing stability work.

### Description
- Add `docs/project/project-rating-2026-04-02.md`, a docs-only file containing an overall numeric rating, listed strengths, the single failing test observed, and next-step recommendations; no runtime or source code changes were made.

### Testing
- Ran `cargo fmt --all -- --check` (passed), `cargo clippy --all-targets -- -D warnings` (passed), and `cargo test` (ran ~4,699 tests: 4,695 passed, 1 failed — `tools::lsp_client::tests::manager_supports_symbols_definitions_and_references` failed with an `initialize` timeout of 10000ms; 3 ignored).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ce26327854832380083a82094851d9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
