### PR TITLE
Restore Python CI contract alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # R.A.I.N. Lab
 
-**A private-by-default experts in your pocket for researchers, independent thinkers, and R&D teams.**
+**A private-by-default expert panel in a box for researchers, independent thinkers, and R&D teams.**
 
-Ask a research question. The R.A.I.N. Lab assembles multiple expert perspectives, grounds strong claims in papers or explicit evidence, and returns the strongest explanations, disagreements, and next moves.
+Ask a raw research question. The R.A.I.N. Lab assembles multiple expert perspectives, grounds strong claims in papers or explicit evidence, and returns the strongest explanations, disagreements, and next moves.
 
 Most tools help you find papers. R.A.I.N. Lab helps you think with a room full of experts.
+
+James is the assistant inside the R.A.I.N. Lab.
 
 <p align="center">
   <img src="assets/rain_lab.png" alt="R.A.I.N. Lab logo" width="800" />

--- a/james_library/utilities/context_manager.py
+++ b/james_library/utilities/context_manager.py
@@ -205,14 +205,25 @@ def _prune_to_budget(
 
 
 def _summarize_messages(messages: list[dict[str, str]]) -> str:
-    lines = [SUMMARY_PREFIX]
-    for message in messages:
+    focus_messages = [
+        message
+        for message in messages
+        if str(message.get("role", "")).strip().lower() == "user"
+    ]
+    if not focus_messages:
+        focus_messages = [message for message in messages if _normalize_whitespace(str(message.get("content", "")))]
+
+    fragments: list[str] = []
+    for message in focus_messages[:2]:
         role = str(message.get("role", "")).strip().lower() or "message"
         content = _normalize_whitespace(str(message.get("content", "")))
         if not content:
             continue
-        lines.append(f"- {role}: {_truncate(content, 48)}")
-    return "\n".join(lines)
+        fragments.append(f"{role}:{_truncate(content, 18)}")
+
+    if not fragments:
+        return SUMMARY_PREFIX
+    return f"{SUMMARY_PREFIX} {'; '.join(fragments)}"
 
 
 def _must_preserve_exact(message: dict[str, str]) -> bool:

--- a/rain_lab_meeting_chat_version.py
+++ b/rain_lab_meeting_chat_version.py
@@ -556,8 +556,8 @@ class Config:
     model_name: str = DEFAULT_MODEL_NAME
 
     max_tokens: int = field(
-        default_factory=lambda: int(os.environ.get("RAIN_CHAT_MAX_TOKENS", "512"))
-    )  # Enough tokens for agents to complete their thoughts
+        default_factory=lambda: int(os.environ.get("RAIN_CHAT_MAX_TOKENS", "320"))
+    )  # Keep Config aligned with the CLI/env default contract
 
     timeout: float = float(os.environ.get("RAIN_LM_TIMEOUT", "300"))
 


### PR DESCRIPTION
## Summary
- align `Config.max_tokens` with the CLI/test contract (`320`)
- restore the README lead-story copy expected by product cohesion tests
- make context-compaction summaries compact enough to survive pruning

## Verification
- `pytest tests/test_input_sanitization.py::TestInputSanitization::test_config_default_max_tokens_matches_cli_default tests/test_product_cohesion_docs.py::test_readme_leads_with_research_panel_positioning -q`
- `pytest tests/test_context_manager.py::test_compact_history_summarizes_safe_middle_before_pruning tests/test_input_sanitization.py::TestInputSanitization::test_config_default_max_tokens_matches_cli_default tests/test_product_cohesion_docs.py::test_readme_leads_with_research_panel_positioning -q`
- `ruff check james_library/utilities/context_manager.py rain_lab_meeting_chat_version.py README.md`
- `pytest tests/ -q`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
