### PR TITLE
Do not use proxy for local Telegram API; add loopback detection and tests

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::fs;
+use url::Url;
 
 /// Telegram's maximum message length for text messages
 const TELEGRAM_MAX_MESSAGE_LENGTH: usize = 4096;
@@ -487,7 +488,22 @@ impl TelegramChannel {
     }
 
     fn http_client(&self) -> reqwest::Client {
+        if self.api_base_targets_loopback() {
+            if let Ok(client) = reqwest::Client::builder().no_proxy().build() {
+                return client;
+            }
+        }
         crate::config::build_channel_proxy_client("channel.telegram", self.proxy_url.as_deref())
+    }
+
+    fn api_base_targets_loopback(&self) -> bool {
+        let Ok(url) = Url::parse(&self.api_base) else {
+            return false;
+        };
+        let Some(host) = url.host_str() else {
+            return false;
+        };
+        matches!(host, "localhost" | "127.0.0.1" | "::1")
     }
 
     fn normalize_identity(value: &str) -> String {
@@ -649,7 +665,7 @@ impl TelegramChannel {
         };
 
         let delete_resp = self
-            .client
+            .http_client()
             .post(self.api_url("deleteMessage"))
             .json(&serde_json::json!({
                 "chat_id": chat_id,
@@ -2336,7 +2352,7 @@ impl Channel for TelegramChannel {
         }
 
         let resp = self
-            .client
+            .http_client()
             .post(self.api_url("sendMessage"))
             .json(&body)
             .send()
@@ -2410,7 +2426,7 @@ impl Channel for TelegramChannel {
         });
 
         let resp = self
-            .client
+            .http_client()
             .post(self.api_url("editMessageText"))
             .json(&body)
             .send()
@@ -2508,7 +2524,7 @@ impl Channel for TelegramChannel {
         });
 
         let resp = self
-            .client
+            .http_client()
             .post(self.api_url("editMessageText"))
             .json(&body)
             .send()
@@ -2532,7 +2548,7 @@ impl Channel for TelegramChannel {
         });
 
         let resp = self
-            .client
+            .http_client()
             .post(self.api_url("editMessageText"))
             .json(&plain_body)
             .send()
@@ -2572,7 +2588,7 @@ impl Channel for TelegramChannel {
         };
 
         let response = self
-            .client
+            .http_client()
             .post(self.api_url("deleteMessage"))
             .json(&serde_json::json!({
                 "chat_id": chat_id,
@@ -2962,6 +2978,20 @@ mod tests {
     fn telegram_channel_name() {
         let ch = TelegramChannel::new("fake-token".into(), vec!["*".into()], false);
         assert_eq!(ch.name(), "telegram");
+    }
+
+    #[test]
+    fn api_base_targets_loopback_true_for_localhost() {
+        let ch = TelegramChannel::new("fake-token".into(), vec!["*".into()], false)
+            .with_api_base("http://localhost:3000".into());
+        assert!(ch.api_base_targets_loopback());
+    }
+
+    #[test]
+    fn api_base_targets_loopback_false_for_public_host() {
+        let ch = TelegramChannel::new("fake-token".into(), vec!["*".into()], false)
+            .with_api_base("https://api.telegram.org".into());
+        assert!(!ch.api_base_targets_loopback());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent outgoing Telegram API requests from being routed through a proxy when the configured API base targets a local loopback address to avoid proxying failures and reachability issues.
- Centralize creation of an HTTP client per-request so loopback-aware client options can be applied consistently.

### Description
- Added `api_base_targets_loopback()` which parses the channel `api_base` using `Url` and returns true for hosts `localhost`, `127.0.0.1`, or `::1` and false on parse errors or other hosts.
- Updated `http_client()` to build and return a `reqwest::Client` with `.no_proxy()` when `api_base_targets_loopback()` is true, falling back to the existing `build_channel_proxy_client` path otherwise.
- Replaced direct uses of the stored `client` with calls to `http_client()` in several places (`delete_draft_for_replacement`, `send_draft`, `update_draft`, `finalize_draft`, `cancel_draft`, and others) so the loopback-aware client is used for those requests.
- Added unit tests `api_base_targets_loopback_true_for_localhost` and `api_base_targets_loopback_false_for_public_host` to validate loopback detection behavior and imported `url::Url` for parsing.

### Testing
- Ran unit tests with `cargo test`, which included the new `api_base_targets_loopback_*` tests and existing Telegram channel tests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cf0cf25c648323b5809ed914354687)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
