### PR TITLE
ci: Migrate from Blacksmith to ubuntu-latest runners

### DIFF
--- a/.github/workflows/ci-build-fast.yml
+++ b/.github/workflows/ci-build-fast.yml
@@ -23,7 +23,7 @@ env:
 jobs:
     changes:
         name: Detect Change Scope
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         outputs:
             rust_changed: ${{ steps.scope.outputs.rust_changed }}
             docs_only: ${{ steps.scope.outputs.docs_only }}
@@ -44,7 +44,7 @@ jobs:
         name: Build (Fast)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.workflow_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -53,10 +53,13 @@ jobs:
               with:
                   toolchain: 1.92.0
 
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
               with:
                   prefix-key: fast-build
                   cache-targets: true
+
+            - name: Ensure web/dist placeholder exists
+              run: mkdir -p web/dist && touch web/dist/.gitkeep
 
             - name: Build release binary
               run: cargo build --release --locked --verbose

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -19,13 +19,15 @@ env:
 jobs:
     integration-tests:
         name: Integration / E2E Tests
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
                   toolchain: 1.92.0
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+            - name: Ensure web/dist placeholder exists
+              run: mkdir -p web/dist && touch web/dist/.gitkeep
             - name: Run integration / E2E tests
               run: cargo test --test agent_e2e --locked --verbose


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: CI workflows are using custom Blacksmith runners (`blacksmith-2vcpu-ubuntu-2404`) which may have maintenance or availability concerns
- Why it matters: Standardizing on `ubuntu-latest` reduces infrastructure dependencies and improves CI reliability
- What changed: 
  - Replaced `blacksmith-2vcpu-ubuntu-2404` with `ubuntu-latest` in fast build and E2E test workflows
  - Migrated rust-cache action from `useblacksmith/rust-cache@v3` to `Swatinem/rust-cache@v2`
  - Added explicit `web/dist` placeholder creation step to ensure directory structure exists
- What did **not** change: Build logic, test execution, Rust toolchain version (1.92.0), or cache configuration strategy

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `ci`
- Module labels: N/A
- Contributor tier label: Auto-managed
- If any auto-label is incorrect: None

## Change Metadata

- Change type: `chore`
- Primary scope: `ci`

## Linked Issue

- Closes: (none identified)
- Related: (none identified)

## Validation Evidence (required)

- Evidence provided: CI workflow syntax is valid YAML; changes are configuration-only with no source code logic modifications
- If any command is intentionally skipped: N/A—this is a CI configuration change, not a code change requiring local testing

## Quality Delta (required for medium/high risk changes)

- Quality delta required: `No`
- This is a runner and action migration with no logic changes; existing test coverage remains unchanged

## Security Impact (required)

- New permissions/capabilities: `No`
- New external network calls: `No`
- Secrets/tokens handling changed: `No`
- File system access scope changed: `No`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- No user-facing changes or data handling modifications

## Compatibility / Migration

- Backward compatible: `Yes`
- Config/env changes: `No` (runner and action versions are internal CI infrastructure)
- Migration needed: `No`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered: `No`

## Human Verification (required)

- Verified scenarios: CI workflow YAML syntax validated; runner and action references are standard GitHub Actions ecosystem components
- Edge cases checked: N/A
- What was not verified: Actual CI execution (will be validated by GitHub Actions on merge)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Fast build and E2E test CI pipelines
- Potential unintended effects: None identified; `ubuntu-latest` is a stable, widely-used runner with equivalent or better resource availability than custom Blacksmith runners
- Guardrails/monitoring: GitHub Actions will report any runner availability or action compatibility issues immediately

## Rollback Plan (required)

- Fast rollback command/path: Revert commit to restore `blacksmith-2vcpu-ubuntu-2404` and `useblacksmith/rust-cache@v3` references
- Feature flags or config toggles: None
- Observable failure symptoms: CI job failures due to runner unavailability or action incompatibility (would appear in GitHub Actions logs)

## Risks and Mitigations

- Risk: `ubuntu-latest` runner performance differs from Blacksmith runners
  - Mitigation: Timeout values (25 min for build, 30 min for E2E) are conservative and should accommodate standard GitHub runners; monitor first few runs for performance regression

https://claude.ai/code/session_01VyQKUwnqizrL1yGPyF5A9p
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
