### PR TITLE
feat(tool): add TRIBE v2 brain-encoding model integration

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,9 +27,9 @@ pub use schema::{
     SchedulerConfig, SecretsConfig, SecurityConfig, SecurityOpsConfig, SkillCreationConfig,
     SkillsConfig, SkillsPromptInjectionMode, SlackConfig, StorageConfig, StorageProviderConfig,
     StorageProviderSection, StreamMode, SwarmConfig, SwarmStrategy, TelegramConfig,
-    TextBrowserConfig, ToolFilterGroup, ToolFilterGroupMode, TranscriptionConfig, TtsConfig,
-    TunnelConfig, VerifiableIntentConfig, WebFetchConfig, WebSearchConfig, WebhookConfig,
-    WhatsAppChatPolicy, WhatsAppWebMode, WorkspaceConfig, DEFAULT_GWS_SERVICES,
+    TextBrowserConfig, ToolFilterGroup, ToolFilterGroupMode, TranscriptionConfig, TribeV2Config,
+    TtsConfig, TunnelConfig, VerifiableIntentConfig, WebFetchConfig, WebSearchConfig,
+    WebhookConfig, WhatsAppChatPolicy, WhatsAppWebMode, WorkspaceConfig, DEFAULT_GWS_SERVICES,
 };
 
 pub fn name_and_presence<T: traits::ChannelConfig>(channel: Option<&T>) -> (&'static str, bool) {

--- a/src/config/schema/root_config.rs
+++ b/src/config/schema/root_config.rs
@@ -321,6 +321,10 @@ pub struct Config {
     /// Claude Code tool configuration (`[claude_code]`).
     #[serde(default)]
     pub claude_code: ClaudeCodeConfig,
+
+    /// TRIBE v2 brain-encoding model sidecar configuration (`[tribev2]`).
+    #[serde(default)]
+    pub tribev2: TribeV2Config,
 }
 
 /// Multi-client workspace isolation configuration.
@@ -604,6 +608,7 @@ impl Default for Config {
             locale: None,
             verifiable_intent: VerifiableIntentConfig::default(),
             claude_code: ClaudeCodeConfig::default(),
+            tribev2: TribeV2Config::default(),
         }
     }
 }

--- a/src/config/schema/security.rs
+++ b/src/config/schema/security.rs
@@ -565,3 +565,50 @@ impl Default for JiraConfig {
         }
     }
 }
+
+/// TRIBE v2 brain-encoding model integration configuration (`[tribev2]`).
+///
+/// When `enabled = true`, registers the `tribev2_predict` tool which sends
+/// multimedia inputs (video, audio, text) to a TRIBE v2 sidecar HTTP service
+/// and returns predicted fMRI brain activation maps on the fsaverage5 cortical mesh.
+///
+/// ## Prerequisites
+/// A running TRIBE v2 sidecar service (see `tools/tribev2_sidecar/`).
+///
+/// ## Defaults
+/// - `enabled`: `false`
+/// - `endpoint`: `"http://127.0.0.1:8100"`
+/// - `timeout_secs`: `120`
+///
+/// ## License
+/// TRIBE v2 is licensed under CC-BY-NC 4.0 (non-commercial use only).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TribeV2Config {
+    /// Enable the `tribev2_predict` tool. Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Base URL of the TRIBE v2 sidecar HTTP service.
+    #[serde(default = "default_tribev2_endpoint")]
+    pub endpoint: String,
+    /// Request timeout in seconds. Default: `120`.
+    #[serde(default = "default_tribev2_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+fn default_tribev2_endpoint() -> String {
+    "http://127.0.0.1:8100".into()
+}
+
+fn default_tribev2_timeout_secs() -> u64 {
+    120
+}
+
+impl Default for TribeV2Config {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint: default_tribev2_endpoint(),
+            timeout_secs: default_tribev2_timeout_secs(),
+        }
+    }
+}

--- a/src/config/schema/tests.rs
+++ b/src/config/schema/tests.rs
@@ -489,6 +489,7 @@ async fn config_toml_roundtrip() {
         locale: None,
         verifiable_intent: VerifiableIntentConfig::default(),
         claude_code: ClaudeCodeConfig::default(),
+        tribev2: TribeV2Config::default(),
     };
 
     let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -867,6 +868,7 @@ async fn config_save_and_load_tmpdir() {
         locale: None,
         verifiable_intent: VerifiableIntentConfig::default(),
         claude_code: ClaudeCodeConfig::default(),
+        tribev2: TribeV2Config::default(),
     };
 
     config.save().await.unwrap();

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -201,6 +201,7 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
         locale: None,
         verifiable_intent: crate::config::VerifiableIntentConfig::default(),
         claude_code: crate::config::ClaudeCodeConfig::default(),
+        tribev2: crate::config::TribeV2Config::default(),
     };
 
     println!(
@@ -611,6 +612,7 @@ async fn run_quick_setup_with_home(
         locale: None,
         verifiable_intent: crate::config::VerifiableIntentConfig::default(),
         claude_code: crate::config::ClaudeCodeConfig::default(),
+        tribev2: crate::config::TribeV2Config::default(),
     };
 
     config.save().await?;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -85,6 +85,7 @@ pub mod tool_discovery;
 pub mod tool_search;
 pub mod toolbox_manager;
 pub mod traits;
+pub mod tribev2;
 pub mod verifiable_intent;
 pub mod weather_tool;
 pub mod web_fetch;
@@ -163,6 +164,7 @@ pub use toolbox_manager::{
     ToolboxManager,
 };
 pub use traits::Tool;
+pub use tribev2::TribeV2Tool;
 #[allow(unused_imports)]
 pub use traits::{ToolResult, ToolSpec};
 pub use verifiable_intent::VerifiableIntentTool;
@@ -676,6 +678,14 @@ pub fn all_tools_with_runtime(
         tool_arcs.push(Arc::new(ClaudeCodeTool::new(
             security.clone(),
             root_config.claude_code.clone(),
+        )));
+    }
+
+    // TRIBE v2 brain-encoding model (requires external sidecar)
+    if root_config.tribev2.enabled {
+        tool_arcs.push(Arc::new(TribeV2Tool::new(
+            root_config.tribev2.endpoint.clone(),
+            root_config.tribev2.timeout_secs,
         )));
     }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -686,6 +686,7 @@ pub fn all_tools_with_runtime(
         tool_arcs.push(Arc::new(TribeV2Tool::new(
             root_config.tribev2.endpoint.clone(),
             root_config.tribev2.timeout_secs,
+            security.clone(),
         )));
     }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -164,9 +164,9 @@ pub use toolbox_manager::{
     ToolboxManager,
 };
 pub use traits::Tool;
-pub use tribev2::TribeV2Tool;
 #[allow(unused_imports)]
 pub use traits::{ToolResult, ToolSpec};
+pub use tribev2::TribeV2Tool;
 pub use verifiable_intent::VerifiableIntentTool;
 pub use weather_tool::WeatherTool;
 pub use web_fetch::WebFetchTool;

--- a/src/tools/tribev2.rs
+++ b/src/tools/tribev2.rs
@@ -1,0 +1,440 @@
+//! TRIBE v2 brain-encoding tool — predicts fMRI brain responses from multimedia.
+//!
+//! Delegates to a TRIBE v2 Python sidecar HTTP service (see `tools/tribev2_sidecar/`).
+//! The sidecar wraps Facebook Research's TRIBE v2 model, which predicts cortical
+//! activation on the fsaverage5 mesh (~20k vertices) from video, audio, or text.
+//!
+//! **License**: TRIBE v2 is CC-BY-NC 4.0 (non-commercial use only).
+
+use super::traits::{Tool, ToolResult};
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::time::Duration;
+
+const CONNECT_TIMEOUT_SECS: u64 = 10;
+
+// ── Sidecar response types ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct PredictResponse {
+    /// Shape description, e.g. "(N, 20484)"
+    shape: String,
+    /// Number of time segments
+    num_segments: usize,
+    /// Per-segment summary statistics
+    segments: Vec<SegmentSummary>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SegmentSummary {
+    index: usize,
+    mean_activation: f64,
+    max_activation: f64,
+    min_activation: f64,
+}
+
+#[derive(Debug, Deserialize)]
+struct HealthResponse {
+    status: String,
+    model_loaded: bool,
+}
+
+// ── Tool struct ─────────────────────────────────────────────────────────────
+
+/// Predicts fMRI brain responses from multimedia via a TRIBE v2 sidecar service.
+pub struct TribeV2Tool {
+    endpoint: String,
+    timeout_secs: u64,
+}
+
+impl TribeV2Tool {
+    pub fn new(endpoint: String, timeout_secs: u64) -> Self {
+        Self {
+            endpoint: endpoint.trim_end_matches('/').to_string(),
+            timeout_secs,
+        }
+    }
+
+    fn build_client(&self) -> anyhow::Result<reqwest::Client> {
+        let builder = reqwest::Client::builder()
+            .timeout(Duration::from_secs(self.timeout_secs))
+            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
+            .user_agent("R.A.I.N.-tribev2/1.0");
+
+        let builder =
+            crate::config::apply_runtime_proxy_to_builder(builder, "tool.tribev2");
+        Ok(builder.build()?)
+    }
+
+    async fn predict(&self, input_type: &str, input_value: &str) -> anyhow::Result<String> {
+        let client = self.build_client()?;
+        let url = format!("{}/predict", self.endpoint);
+
+        let body = json!({
+            "input_type": input_type,
+            "input_value": input_value,
+        });
+
+        let response = client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to connect to TRIBE v2 sidecar at {}: {}. \
+                     Ensure the sidecar is running (see tools/tribev2_sidecar/README.md).",
+                    self.endpoint,
+                    e
+                )
+            })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "TRIBE v2 sidecar returned HTTP {status}: {error_body}"
+            );
+        }
+
+        let result: PredictResponse = response.json().await.map_err(|e| {
+            anyhow::anyhow!("Failed to parse TRIBE v2 response: {e}")
+        })?;
+
+        Ok(Self::format_output(&result, input_type, input_value))
+    }
+
+    async fn health(&self) -> anyhow::Result<String> {
+        let client = self.build_client()?;
+        let url = format!("{}/health", self.endpoint);
+
+        let response = client.get(&url).send().await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to connect to TRIBE v2 sidecar at {}: {}",
+                self.endpoint,
+                e
+            )
+        })?;
+
+        let result: HealthResponse = response.json().await?;
+        Ok(format!(
+            "TRIBE v2 sidecar status: {} | Model loaded: {}",
+            result.status, result.model_loaded
+        ))
+    }
+
+    fn format_output(result: &PredictResponse, input_type: &str, input_value: &str) -> String {
+        let mut out = String::new();
+        out.push_str(&format!(
+            "TRIBE v2 Brain Prediction\n\
+             ─────────────────────────\n\
+             Input type : {input_type}\n\
+             Input      : {input_value}\n\
+             Prediction shape: {} ({} segments x fsaverage5 vertices)\n",
+            result.shape, result.num_segments,
+        ));
+
+        if !result.segments.is_empty() {
+            out.push_str("\nSegment Summaries\n─────────────────\n");
+            for seg in &result.segments {
+                out.push_str(&format!(
+                    "  Segment {:3}: mean={:.4}  max={:.4}  min={:.4}\n",
+                    seg.index, seg.mean_activation, seg.max_activation, seg.min_activation,
+                ));
+            }
+        }
+
+        out
+    }
+}
+
+// ── Tool trait ──────────────────────────────────────────────────────────────
+
+#[async_trait]
+impl Tool for TribeV2Tool {
+    fn name(&self) -> &str {
+        "tribev2_predict"
+    }
+
+    fn description(&self) -> &str {
+        "Predict fMRI brain responses from multimedia inputs using Facebook Research's \
+         TRIBE v2 model. Accepts video file paths, audio file paths, or raw text. \
+         Returns predicted cortical activation on the fsaverage5 mesh (~20k vertices). \
+         Requires a running TRIBE v2 sidecar service."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["predict", "health"],
+                    "description": "Action to perform. 'predict' runs brain encoding on input. \
+                                    'health' checks sidecar status. Default: 'predict'."
+                },
+                "input_type": {
+                    "type": "string",
+                    "enum": ["video", "audio", "text"],
+                    "description": "Type of input stimulus. Required for 'predict' action."
+                },
+                "input_value": {
+                    "type": "string",
+                    "description": "For 'video'/'audio': absolute file path accessible to the \
+                                    sidecar. For 'text': the raw text string. Required for \
+                                    'predict' action."
+                }
+            },
+            "required": []
+        })
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let action = args
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("predict");
+
+        match action {
+            "health" => match self.health().await {
+                Ok(output) => Ok(ToolResult {
+                    success: true,
+                    output,
+                    error: None,
+                }),
+                Err(e) => Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(e.to_string()),
+                }),
+            },
+            "predict" => {
+                let input_type = match args.get("input_type").and_then(|v| v.as_str()) {
+                    Some(t) if matches!(t, "video" | "audio" | "text") => t,
+                    Some(t) => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some(format!(
+                                "Invalid input_type '{t}'. Must be 'video', 'audio', or 'text'."
+                            )),
+                        });
+                    }
+                    None => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some(
+                                "Missing required parameter 'input_type' for predict action."
+                                    .into(),
+                            ),
+                        });
+                    }
+                };
+
+                let input_value =
+                    match args.get("input_value").and_then(|v| v.as_str()) {
+                        Some(v) if !v.trim().is_empty() => v.trim(),
+                        _ => {
+                            return Ok(ToolResult {
+                                success: false,
+                                output: String::new(),
+                                error: Some(
+                                    "Missing required parameter 'input_value' for predict action."
+                                        .into(),
+                                ),
+                            });
+                        }
+                    };
+
+                match self.predict(input_type, input_value).await {
+                    Ok(output) => Ok(ToolResult {
+                        success: true,
+                        output,
+                        error: None,
+                    }),
+                    Err(e) => Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(e.to_string()),
+                    }),
+                }
+            }
+            other => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Unknown action '{other}'. Must be 'predict' or 'health'."
+                )),
+            }),
+        }
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tool() -> TribeV2Tool {
+        TribeV2Tool::new("http://127.0.0.1:8100".into(), 120)
+    }
+
+    #[test]
+    fn name_is_tribev2_predict() {
+        assert_eq!(make_tool().name(), "tribev2_predict");
+    }
+
+    #[test]
+    fn description_is_non_empty() {
+        assert!(!make_tool().description().is_empty());
+    }
+
+    #[test]
+    fn parameters_schema_is_valid_object() {
+        let schema = make_tool().parameters_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"].is_object());
+    }
+
+    #[test]
+    fn schema_has_action_property() {
+        let schema = make_tool().parameters_schema();
+        let action = &schema["properties"]["action"];
+        assert!(action.is_object());
+        let enums = action["enum"].as_array().unwrap();
+        assert!(enums.contains(&Value::String("predict".into())));
+        assert!(enums.contains(&Value::String("health".into())));
+    }
+
+    #[test]
+    fn schema_has_input_type_property() {
+        let schema = make_tool().parameters_schema();
+        let input_type = &schema["properties"]["input_type"];
+        let enums = input_type["enum"].as_array().unwrap();
+        assert!(enums.contains(&Value::String("video".into())));
+        assert!(enums.contains(&Value::String("audio".into())));
+        assert!(enums.contains(&Value::String("text".into())));
+    }
+
+    #[test]
+    fn schema_has_input_value_property() {
+        let schema = make_tool().parameters_schema();
+        assert!(schema["properties"]["input_value"].is_object());
+    }
+
+    #[test]
+    fn endpoint_trailing_slash_stripped() {
+        let tool = TribeV2Tool::new("http://localhost:8100/".into(), 60);
+        assert_eq!(tool.endpoint, "http://localhost:8100");
+    }
+
+    #[test]
+    fn spec_reflects_tool_metadata() {
+        let tool = make_tool();
+        let spec = tool.spec();
+        assert_eq!(spec.name, "tribev2_predict");
+        assert_eq!(spec.description, tool.description());
+        assert!(spec.parameters.is_object());
+    }
+
+    #[test]
+    fn format_output_contains_expected_fields() {
+        let result = PredictResponse {
+            shape: "(10, 20484)".into(),
+            num_segments: 10,
+            segments: vec![
+                SegmentSummary {
+                    index: 0,
+                    mean_activation: 0.1234,
+                    max_activation: 0.9876,
+                    min_activation: -0.5432,
+                },
+                SegmentSummary {
+                    index: 1,
+                    mean_activation: 0.2345,
+                    max_activation: 0.8765,
+                    min_activation: -0.4321,
+                },
+            ],
+        };
+
+        let out = TribeV2Tool::format_output(&result, "video", "/path/to/video.mp4");
+        assert!(out.contains("TRIBE v2 Brain Prediction"));
+        assert!(out.contains("video"));
+        assert!(out.contains("/path/to/video.mp4"));
+        assert!(out.contains("(10, 20484)"));
+        assert!(out.contains("10 segments"));
+        assert!(out.contains("Segment   0"));
+        assert!(out.contains("0.1234"));
+        assert!(out.contains("0.9876"));
+    }
+
+    #[test]
+    fn format_output_empty_segments() {
+        let result = PredictResponse {
+            shape: "(0, 20484)".into(),
+            num_segments: 0,
+            segments: vec![],
+        };
+
+        let out = TribeV2Tool::format_output(&result, "text", "hello world");
+        assert!(out.contains("TRIBE v2 Brain Prediction"));
+        assert!(out.contains("text"));
+        assert!(!out.contains("Segment Summaries"));
+    }
+
+    // ── execute: parameter validation (no network needed) ───────────────────
+
+    #[tokio::test]
+    async fn execute_missing_input_type_returns_error() {
+        let result = make_tool()
+            .execute(json!({"action": "predict", "input_value": "hello"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("input_type"));
+    }
+
+    #[tokio::test]
+    async fn execute_missing_input_value_returns_error() {
+        let result = make_tool()
+            .execute(json!({"action": "predict", "input_type": "text"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("input_value"));
+    }
+
+    #[tokio::test]
+    async fn execute_invalid_input_type_returns_error() {
+        let result = make_tool()
+            .execute(json!({"action": "predict", "input_type": "image", "input_value": "test"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Invalid input_type"));
+    }
+
+    #[tokio::test]
+    async fn execute_empty_input_value_returns_error() {
+        let result = make_tool()
+            .execute(json!({"action": "predict", "input_type": "text", "input_value": "   "}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("input_value"));
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_action_returns_error() {
+        let result = make_tool()
+            .execute(json!({"action": "train"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Unknown action"));
+    }
+}

--- a/src/tools/tribev2.rs
+++ b/src/tools/tribev2.rs
@@ -7,10 +7,13 @@
 //! **License**: TRIBE v2 is CC-BY-NC 4.0 (non-commercial use only).
 
 use super::traits::{Tool, ToolResult};
+use crate::security::policy::ToolOperation;
+use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::fmt::Write;
+use std::sync::Arc;
 use std::time::Duration;
 
 const CONNECT_TIMEOUT_SECS: u64 = 10;
@@ -45,13 +48,15 @@ struct HealthResponse {
 
 /// Predicts fMRI brain responses from multimedia via a TRIBE v2 sidecar service.
 pub struct TribeV2Tool {
+    security: Arc<SecurityPolicy>,
     endpoint: String,
     timeout_secs: u64,
 }
 
 impl TribeV2Tool {
-    pub fn new(endpoint: String, timeout_secs: u64) -> Self {
+    pub fn new(endpoint: String, timeout_secs: u64, security: Arc<SecurityPolicy>) -> Self {
         Self {
+            security,
             endpoint: endpoint.trim_end_matches('/').to_string(),
             timeout_secs,
         }
@@ -110,6 +115,12 @@ impl TribeV2Tool {
                 e
             )
         })?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_body = response.text().await.unwrap_or_default();
+            anyhow::bail!("TRIBE v2 sidecar health check returned HTTP {status}: {error_body}");
+        }
 
         let result: HealthResponse = response.json().await?;
         Ok(format!(
@@ -191,6 +202,21 @@ impl Tool for TribeV2Tool {
             .get("action")
             .and_then(|v| v.as_str())
             .unwrap_or("predict");
+
+        let operation = match action {
+            "health" => ToolOperation::Read,
+            _ => ToolOperation::Act,
+        };
+        if let Err(error) = self
+            .security
+            .enforce_tool_operation(operation, "tribev2_predict")
+        {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(error.to_string()),
+            });
+        }
 
         match action {
             "health" => match self.health().await {
@@ -274,7 +300,11 @@ mod tests {
     use super::*;
 
     fn make_tool() -> TribeV2Tool {
-        TribeV2Tool::new("http://127.0.0.1:8100".into(), 120)
+        TribeV2Tool::new(
+            "http://127.0.0.1:8100".into(),
+            120,
+            Arc::new(SecurityPolicy::default()),
+        )
     }
 
     #[test]
@@ -322,7 +352,11 @@ mod tests {
 
     #[test]
     fn endpoint_trailing_slash_stripped() {
-        let tool = TribeV2Tool::new("http://localhost:8100/".into(), 60);
+        let tool = TribeV2Tool::new(
+            "http://localhost:8100/".into(),
+            60,
+            Arc::new(SecurityPolicy::default()),
+        );
         assert_eq!(tool.endpoint, "http://localhost:8100");
     }
 

--- a/src/tools/tribev2.rs
+++ b/src/tools/tribev2.rs
@@ -133,9 +133,9 @@ impl TribeV2Tool {
         if !result.segments.is_empty() {
             out.push_str("\nSegment Summaries\n─────────────────\n");
             for seg in &result.segments {
-                let _ = write!(
+                let _ = writeln!(
                     out,
-                    "  Segment {:3}: mean={:.4}  max={:.4}  min={:.4}\n",
+                    "  Segment {:3}: mean={:.4}  max={:.4}  min={:.4}",
                     seg.index, seg.mean_activation, seg.max_activation, seg.min_activation,
                 );
             }

--- a/src/tools/tribev2.rs
+++ b/src/tools/tribev2.rs
@@ -10,6 +10,7 @@ use super::traits::{Tool, ToolResult};
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::{json, Value};
+use std::fmt::Write;
 use std::time::Duration;
 
 const CONNECT_TIMEOUT_SECS: u64 = 10;
@@ -62,8 +63,7 @@ impl TribeV2Tool {
             .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT_SECS))
             .user_agent("R.A.I.N.-tribev2/1.0");
 
-        let builder =
-            crate::config::apply_runtime_proxy_to_builder(builder, "tool.tribev2");
+        let builder = crate::config::apply_runtime_proxy_to_builder(builder, "tool.tribev2");
         Ok(builder.build()?)
     }
 
@@ -76,31 +76,25 @@ impl TribeV2Tool {
             "input_value": input_value,
         });
 
-        let response = client
-            .post(&url)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "Failed to connect to TRIBE v2 sidecar at {}: {}. \
+        let response = client.post(&url).json(&body).send().await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to connect to TRIBE v2 sidecar at {}: {}. \
                      Ensure the sidecar is running (see tools/tribev2_sidecar/README.md).",
-                    self.endpoint,
-                    e
-                )
-            })?;
+                self.endpoint,
+                e
+            )
+        })?;
 
         let status = response.status();
         if !status.is_success() {
             let error_body = response.text().await.unwrap_or_default();
-            anyhow::bail!(
-                "TRIBE v2 sidecar returned HTTP {status}: {error_body}"
-            );
+            anyhow::bail!("TRIBE v2 sidecar returned HTTP {status}: {error_body}");
         }
 
-        let result: PredictResponse = response.json().await.map_err(|e| {
-            anyhow::anyhow!("Failed to parse TRIBE v2 response: {e}")
-        })?;
+        let result: PredictResponse = response
+            .json()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to parse TRIBE v2 response: {e}"))?;
 
         Ok(Self::format_output(&result, input_type, input_value))
     }
@@ -126,22 +120,24 @@ impl TribeV2Tool {
 
     fn format_output(result: &PredictResponse, input_type: &str, input_value: &str) -> String {
         let mut out = String::new();
-        out.push_str(&format!(
+        let _ = write!(
+            out,
             "TRIBE v2 Brain Prediction\n\
              ─────────────────────────\n\
              Input type : {input_type}\n\
              Input      : {input_value}\n\
              Prediction shape: {} ({} segments x fsaverage5 vertices)\n",
             result.shape, result.num_segments,
-        ));
+        );
 
         if !result.segments.is_empty() {
             out.push_str("\nSegment Summaries\n─────────────────\n");
             for seg in &result.segments {
-                out.push_str(&format!(
+                let _ = write!(
+                    out,
                     "  Segment {:3}: mean={:.4}  max={:.4}  min={:.4}\n",
                     seg.index, seg.mean_activation, seg.max_activation, seg.min_activation,
-                ));
+                );
             }
         }
 
@@ -233,20 +229,19 @@ impl Tool for TribeV2Tool {
                     }
                 };
 
-                let input_value =
-                    match args.get("input_value").and_then(|v| v.as_str()) {
-                        Some(v) if !v.trim().is_empty() => v.trim(),
-                        _ => {
-                            return Ok(ToolResult {
-                                success: false,
-                                output: String::new(),
-                                error: Some(
-                                    "Missing required parameter 'input_value' for predict action."
-                                        .into(),
-                                ),
-                            });
-                        }
-                    };
+                let input_value = match args.get("input_value").and_then(|v| v.as_str()) {
+                    Some(v) if !v.trim().is_empty() => v.trim(),
+                    _ => {
+                        return Ok(ToolResult {
+                            success: false,
+                            output: String::new(),
+                            error: Some(
+                                "Missing required parameter 'input_value' for predict action."
+                                    .into(),
+                            ),
+                        });
+                    }
+                };
 
                 match self.predict(input_type, input_value).await {
                     Ok(output) => Ok(ToolResult {

--- a/tools/tribev2_sidecar/README.md
+++ b/tools/tribev2_sidecar/README.md
@@ -1,0 +1,83 @@
+# TRIBE v2 Sidecar Service
+
+Thin HTTP wrapper around Facebook Research's [TRIBE v2](https://github.com/facebookresearch/tribev2) brain-encoding model, designed to be called by the R.A.I.N. `tribev2_predict` tool.
+
+## License
+
+TRIBE v2 is licensed under **CC-BY-NC 4.0** (non-commercial use only).
+
+## Prerequisites
+
+- Python 3.11+
+- GPU recommended (CUDA-capable) for reasonable inference times
+- ~4 GB disk for model weights (downloaded on first run from HuggingFace)
+
+## Setup
+
+```bash
+cd tools/tribev2_sidecar
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+python server.py                          # default: 0.0.0.0:8100
+python server.py --port 9000              # custom port
+python server.py --host 127.0.0.1         # bind to localhost only
+python server.py --cache-dir ./my_cache   # custom model cache directory
+```
+
+## R.A.I.N. Configuration
+
+In your `config.toml`:
+
+```toml
+[tribev2]
+enabled = true
+endpoint = "http://127.0.0.1:8100"
+timeout_secs = 120
+```
+
+## API
+
+### `POST /predict`
+
+```json
+{
+  "input_type": "video",
+  "input_value": "/absolute/path/to/video.mp4"
+}
+```
+
+`input_type` accepts `"video"`, `"audio"`, or `"text"`.
+For video/audio, `input_value` is a file path accessible to the sidecar.
+For text, `input_value` is the raw text string.
+
+Response:
+
+```json
+{
+  "shape": "(10, 20484)",
+  "num_segments": 10,
+  "segments": [
+    {
+      "index": 0,
+      "mean_activation": 0.1234,
+      "max_activation": 0.9876,
+      "min_activation": -0.5432
+    }
+  ]
+}
+```
+
+### `GET /health`
+
+```json
+{
+  "status": "ok",
+  "model_loaded": true
+}
+```

--- a/tools/tribev2_sidecar/README.md
+++ b/tools/tribev2_sidecar/README.md
@@ -24,9 +24,9 @@ pip install -r requirements.txt
 ## Running
 
 ```bash
-python server.py                          # default: 0.0.0.0:8100
+python server.py                          # default: 127.0.0.1:8100
 python server.py --port 9000              # custom port
-python server.py --host 127.0.0.1         # bind to localhost only
+python server.py --host 0.0.0.0           # bind to all interfaces
 python server.py --cache-dir ./my_cache   # custom model cache directory
 ```
 

--- a/tools/tribev2_sidecar/requirements.txt
+++ b/tools/tribev2_sidecar/requirements.txt
@@ -1,0 +1,3 @@
+tribev2 @ git+https://github.com/facebookresearch/tribev2.git
+fastapi>=0.115.0,<1
+uvicorn[standard]>=0.34.0,<1

--- a/tools/tribev2_sidecar/server.py
+++ b/tools/tribev2_sidecar/server.py
@@ -1,0 +1,161 @@
+"""TRIBE v2 sidecar HTTP service for R.A.I.N. integration.
+
+Wraps Facebook Research's TRIBE v2 brain-encoding model behind a minimal
+FastAPI server so the Rust-side ``tribev2_predict`` tool can call it over HTTP.
+
+Usage::
+
+    python server.py                      # 0.0.0.0:8100
+    python server.py --port 9000          # custom port
+    python server.py --cache-dir ./cache  # custom HuggingFace cache
+
+License: TRIBE v2 is CC-BY-NC 4.0 (non-commercial use only).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("tribev2_sidecar")
+
+app = FastAPI(title="TRIBE v2 Sidecar", version="0.1.0")
+
+# Global model handle — loaded once at startup.
+_model = None
+
+
+class PredictRequest(BaseModel):
+    input_type: str  # "video", "audio", or "text"
+    input_value: str  # file path or raw text
+
+
+class SegmentSummary(BaseModel):
+    index: int
+    mean_activation: float
+    max_activation: float
+    min_activation: float
+
+
+class PredictResponse(BaseModel):
+    shape: str
+    num_segments: int
+    segments: list[SegmentSummary]
+
+
+class HealthResponse(BaseModel):
+    status: str
+    model_loaded: bool
+
+
+@app.get("/health", response_model=HealthResponse)
+def health() -> HealthResponse:
+    return HealthResponse(status="ok", model_loaded=_model is not None)
+
+
+@app.post("/predict", response_model=PredictResponse)
+def predict(req: PredictRequest) -> PredictResponse:
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded yet.")
+
+    if req.input_type not in ("video", "audio", "text"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid input_type '{req.input_type}'. Must be 'video', 'audio', or 'text'.",
+        )
+
+    if not req.input_value.strip():
+        raise HTTPException(status_code=400, detail="input_value must not be empty.")
+
+    if req.input_type in ("video", "audio"):
+        path = Path(req.input_value)
+        if not path.is_file():
+            raise HTTPException(
+                status_code=400,
+                detail=f"File not found: {req.input_value}",
+            )
+
+    try:
+        if req.input_type == "text":
+            preds = _predict_text(req.input_value)
+        else:
+            preds = _predict_media(req.input_value)
+    except Exception as exc:
+        logger.exception("Prediction failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    segments = []
+    for i in range(preds.shape[0]):
+        row = preds[i]
+        segments.append(
+            SegmentSummary(
+                index=i,
+                mean_activation=float(np.mean(row)),
+                max_activation=float(np.max(row)),
+                min_activation=float(np.min(row)),
+            )
+        )
+
+    return PredictResponse(
+        shape=str(preds.shape),
+        num_segments=preds.shape[0],
+        segments=segments,
+    )
+
+
+def _predict_media(file_path: str) -> np.ndarray:
+    """Run prediction on a video or audio file."""
+    df = _model.get_events_dataframe(video_path=file_path)
+    preds, _segments = _model.predict(events=df)
+    return preds
+
+
+def _predict_text(text: str) -> np.ndarray:
+    """Run prediction on raw text by writing a temporary text file."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".txt", delete=False
+    ) as tmp:
+        tmp.write(text)
+        tmp_path = tmp.name
+
+    try:
+        df = _model.get_events_dataframe(video_path=tmp_path)
+        preds, _segments = _model.predict(events=df)
+        return preds
+    finally:
+        os.unlink(tmp_path)
+
+
+def main() -> None:
+    global _model  # noqa: PLW0603
+
+    parser = argparse.ArgumentParser(description="TRIBE v2 sidecar service")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host (default: 0.0.0.0)")
+    parser.add_argument("--port", type=int, default=8100, help="Bind port (default: 8100)")
+    parser.add_argument(
+        "--cache-dir",
+        default="./cache",
+        help="HuggingFace model cache directory (default: ./cache)",
+    )
+    args = parser.parse_args()
+
+    logger.info("Loading TRIBE v2 model (cache_dir=%s) ...", args.cache_dir)
+    from tribev2 import TribeModel
+
+    _model = TribeModel.from_pretrained("facebook/tribev2", cache_folder=args.cache_dir)
+    logger.info("TRIBE v2 model loaded successfully.")
+
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tribev2_sidecar/server.py
+++ b/tools/tribev2_sidecar/server.py
@@ -5,7 +5,7 @@ FastAPI server so the Rust-side ``tribev2_predict`` tool can call it over HTTP.
 
 Usage::
 
-    python server.py                      # 0.0.0.0:8100
+    python server.py                      # 127.0.0.1:8100
     python server.py --port 9000          # custom port
     python server.py --cache-dir ./cache  # custom HuggingFace cache
 

--- a/tools/tribev2_sidecar/server.py
+++ b/tools/tribev2_sidecar/server.py
@@ -87,8 +87,10 @@ def predict(req: PredictRequest) -> PredictResponse:
     try:
         if req.input_type == "text":
             preds = _predict_text(req.input_value)
+        elif req.input_type == "audio":
+            preds = _predict_audio(req.input_value)
         else:
-            preds = _predict_media(req.input_value)
+            preds = _predict_video(req.input_value)
     except Exception as exc:
         logger.exception("Prediction failed")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -112,9 +114,16 @@ def predict(req: PredictRequest) -> PredictResponse:
     )
 
 
-def _predict_media(file_path: str) -> np.ndarray:
-    """Run prediction on a video or audio file."""
+def _predict_video(file_path: str) -> np.ndarray:
+    """Run prediction on a video file."""
     df = _model.get_events_dataframe(video_path=file_path)
+    preds, _segments = _model.predict(events=df)
+    return preds
+
+
+def _predict_audio(file_path: str) -> np.ndarray:
+    """Run prediction on an audio file."""
+    df = _model.get_events_dataframe(audio_path=file_path)
     preds, _segments = _model.predict(events=df)
     return preds
 
@@ -128,7 +137,7 @@ def _predict_text(text: str) -> np.ndarray:
         tmp_path = tmp.name
 
     try:
-        df = _model.get_events_dataframe(video_path=tmp_path)
+        df = _model.get_events_dataframe(text_path=tmp_path)
         preds, _segments = _model.predict(events=df)
         return preds
     finally:
@@ -139,7 +148,7 @@ def main() -> None:
     global _model  # noqa: PLW0603
 
     parser = argparse.ArgumentParser(description="TRIBE v2 sidecar service")
-    parser.add_argument("--host", default="0.0.0.0", help="Bind host (default: 0.0.0.0)")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
     parser.add_argument("--port", type=int, default=8100, help="Bind port (default: 8100)")
     parser.add_argument(
         "--cache-dir",


### PR DESCRIPTION
## Summary

- **Base branch target**: `main`
- **Problem**: R.A.I.N. lacks support for predicting fMRI brain responses from multimedia inputs using state-of-the-art neuroscience models.
- **Why it matters**: Enables cognitive science and neuroscience workflows by integrating Facebook Research's TRIBE v2 model, which predicts cortical activation on the fsaverage5 mesh from video, audio, or text stimuli.
- **What changed**: 
  - Added `TribeV2Tool` (Rust) that delegates to an HTTP sidecar service
  - Added `tribev2_sidecar/` Python service wrapping the TRIBE v2 model
  - Added `TribeV2Config` for configuration management
  - Integrated tool into the toolbox manager with proper config gating
- **What did not change**: No changes to core runtime, memory, or security subsystems; tool is opt-in via config.

## Label Snapshot

- **Risk label**: `risk: low`
- **Size label**: `size: M`
- **Scope labels**: `tool`, `integration`, `config`
- **Module labels**: `tool: tribev2`
- **Contributor tier label**: (auto-managed)
- **Auto-label corrections**: None

## Change Metadata

- **Change type**: `feature`
- **Primary scope**: `tool`

## Linked Issue

- Closes: (none specified)
- Related: (none specified)

## Validation Evidence

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Evidence provided**: Unit tests included for schema validation, parameter validation, output formatting, and endpoint handling. All tests are synchronous or async-compatible and do not require network access (parameter validation tests only).
- **Intentionally skipped commands**: None

## Quality Delta

- **Quality delta required**: No
- **Expected panic count impact**: 0 (no new unwraps in production paths; errors properly propagated via `anyhow::Result`)
- **Expected unwrap count impact**: 0
- **Expected flaky test rate impact**: 0 (no network-dependent tests in unit suite)
- **Expected critical-path test coverage impact**: Minimal (tool is optional, gated by config)

## Security Impact

- **New permissions/capabilities**: No
- **New external network calls**: Yes (HTTP calls to TRIBE v2 sidecar service)
  - **Mitigation**: Calls are to a locally-controlled sidecar (default `http://127.0.0.1:8100`); endpoint is configurable and defaults to localhost. Timeout is configurable (default 120s). No credentials or secrets are transmitted.
- **Secrets/tokens handling changed**: No
- **File system access scope changed**: No (sidecar handles file I/O; Rust tool only passes file paths as strings)

## Privacy and Data Hygiene

- **Data-hygiene status**: `pass`
- **Redaction/anonymization notes**: Tool processes multimedia inputs and returns activation statistics; no PII is logged or stored by the tool itself. Sidecar behavior is documented in `tools/tribev2_sidecar/README.md`.
- **Neutral wording confirmation**: Uses standard neuroscience terminology (fMRI, cortical activation, fsaverage5 mesh); no identity-like wording.

## Compatibility / Migration

- **Backward compatible**: Yes (tool is opt-in; disabled by default)
- **Config/env changes**: Yes
  - New `[tribev2]` section in `config.toml` with fields: `enabled`, `endpoint`, `timeout_secs`
  - Defaults: `enabled = false`, `endpoint = "http://127.0.0.1:8100"`, `timeout_secs = 120`
- **Migration needed**: No (feature is additive and disabled by default)

## i18n Follow-Through

- **i18n follow-through triggered**: No
- **Rationale**: Tool names and descriptions are technical/scientific terms (TRIBE v2, fMRI, fsaverage5) that are not user-facing UI strings requiring localization. Documentation is in English only.

https://claude.ai/code/session_01DZqQfevo1unp7cVrGisR4W
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
