### PR TITLE
feat(organization): add canonical authority policy module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ pub(crate) mod multimodal;
 pub mod nodes;
 pub mod observability;
 pub(crate) mod onboard;
+pub mod organization;
 pub mod peripherals;
 pub mod providers;
 pub mod rag;

--- a/src/organization/mod.rs
+++ b/src/organization/mod.rs
@@ -1,0 +1,173 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AuthorityTier {
+    Operator,
+    Analyst,
+    ResearchLead,
+    Executive,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CanonicalAgent {
+    James,
+    Elena,
+    Jasmine,
+    Luca,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrganizationAction {
+    ReadTelemetry,
+    UpdateRunbook,
+    TriggerExperiment,
+    ApproveDeployment,
+    RotateCredentials,
+    ModifySecurityPolicy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgentIdentity {
+    pub name: &'static str,
+    pub role: &'static str,
+    pub title: &'static str,
+    pub tier: AuthorityTier,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LabOrganization {
+    pub james: AgentIdentity,
+    pub elena: AgentIdentity,
+    pub jasmine: AgentIdentity,
+    pub luca: AgentIdentity,
+}
+
+impl Default for LabOrganization {
+    fn default() -> Self {
+        Self {
+            james: AgentIdentity {
+                name: "James",
+                role: "Program Direction",
+                title: "Executive Director",
+                tier: AuthorityTier::Executive,
+            },
+            elena: AgentIdentity {
+                name: "Elena",
+                role: "Research Governance",
+                title: "Research Lead",
+                tier: AuthorityTier::ResearchLead,
+            },
+            jasmine: AgentIdentity {
+                name: "Jasmine",
+                role: "Data Intelligence",
+                title: "Senior Analyst",
+                tier: AuthorityTier::Analyst,
+            },
+            luca: AgentIdentity {
+                name: "Luca",
+                role: "Operations Execution",
+                title: "Operations Operator",
+                tier: AuthorityTier::Operator,
+            },
+        }
+    }
+}
+
+impl LabOrganization {
+    #[must_use]
+    pub fn identity(&self, agent: CanonicalAgent) -> &AgentIdentity {
+        match agent {
+            CanonicalAgent::James => &self.james,
+            CanonicalAgent::Elena => &self.elena,
+            CanonicalAgent::Jasmine => &self.jasmine,
+            CanonicalAgent::Luca => &self.luca,
+        }
+    }
+
+    #[must_use]
+    pub fn can_request(&self, agent: CanonicalAgent, action: OrganizationAction) -> bool {
+        let tier = self.identity(agent).tier;
+
+        match action {
+            OrganizationAction::ReadTelemetry => tier >= AuthorityTier::Operator,
+            OrganizationAction::UpdateRunbook => tier >= AuthorityTier::Analyst,
+            OrganizationAction::TriggerExperiment => tier >= AuthorityTier::ResearchLead,
+            OrganizationAction::ApproveDeployment => tier >= AuthorityTier::Executive,
+            OrganizationAction::RotateCredentials | OrganizationAction::ModifySecurityPolicy => {
+                tier >= AuthorityTier::Executive
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn requires_human_signature(action: OrganizationAction) -> bool {
+        matches!(
+            action,
+            OrganizationAction::ApproveDeployment
+                | OrganizationAction::RotateCredentials
+                | OrganizationAction::ModifySecurityPolicy
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AuthorityTier, CanonicalAgent, LabOrganization, OrganizationAction};
+
+    #[test]
+    fn canonical_role_to_tier_mapping_is_stable() {
+        let organization = LabOrganization::default();
+
+        assert_eq!(
+            organization.identity(CanonicalAgent::James).tier,
+            AuthorityTier::Executive
+        );
+        assert_eq!(
+            organization.identity(CanonicalAgent::Elena).tier,
+            AuthorityTier::ResearchLead
+        );
+        assert_eq!(
+            organization.identity(CanonicalAgent::Jasmine).tier,
+            AuthorityTier::Analyst
+        );
+        assert_eq!(
+            organization.identity(CanonicalAgent::Luca).tier,
+            AuthorityTier::Operator
+        );
+    }
+
+    #[test]
+    fn authority_tier_ordering_matches_policy_hierarchy() {
+        assert!(AuthorityTier::Operator < AuthorityTier::Analyst);
+        assert!(AuthorityTier::Analyst < AuthorityTier::ResearchLead);
+        assert!(AuthorityTier::ResearchLead < AuthorityTier::Executive);
+    }
+
+    #[test]
+    fn high_stakes_actions_require_signature_and_executive_tier() {
+        let organization = LabOrganization::default();
+
+        assert!(LabOrganization::requires_human_signature(
+            OrganizationAction::ApproveDeployment
+        ));
+        assert!(LabOrganization::requires_human_signature(
+            OrganizationAction::RotateCredentials
+        ));
+        assert!(LabOrganization::requires_human_signature(
+            OrganizationAction::ModifySecurityPolicy
+        ));
+        assert!(!LabOrganization::requires_human_signature(
+            OrganizationAction::ReadTelemetry
+        ));
+
+        assert!(
+            !organization.can_request(CanonicalAgent::Luca, OrganizationAction::RotateCredentials)
+        );
+        assert!(!organization.can_request(
+            CanonicalAgent::Jasmine,
+            OrganizationAction::ApproveDeployment
+        ));
+        assert!(organization.can_request(
+            CanonicalAgent::James,
+            OrganizationAction::ModifySecurityPolicy
+        ));
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralize lab agent identities and access policy so role/tier checks are auditable and consistent across the crate. 
- Provide a single place to express high-stakes gating (human signature) and tier-based permissions.

### Description
- Add new module `src/organization/mod.rs` exposing `LabOrganization`, `AgentIdentity`, `AuthorityTier`, `CanonicalAgent`, and `OrganizationAction` types. 
- Implement `identity(agent)`, `can_request(agent, action)`, and `requires_human_signature(action)` helpers to centralize policy checks. 
- Wire the module into crate exports by adding `pub mod organization;` in `src/lib.rs`. 
- Add focused unit tests in `src/organization/mod.rs` covering role-to-tier mapping, tier ordering/comparison, and high-stakes action gating.

### Testing
- Ran formatting check with `cargo fmt --all -- --check`, which passed. 
- Ran linting with `cargo clippy --all-targets -- -D warnings`, which passed. 
- Ran the full test suite with `cargo test`, including the new unit tests in `src/organization/mod.rs`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3b2d78a5083239e7c78b629b27721)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
