### PR TITLE
fix(provider): preserve final chunk payloads in StreamEvent conversion

### DIFF
--- a/src/providers/traits.rs
+++ b/src/providers/traits.rs
@@ -1027,4 +1027,24 @@ mod tests {
 
         assert!(message.contains("non-prompt-guided"));
     }
+
+    #[test]
+    fn stream_event_from_chunk_preserves_final_payload() {
+        let event = StreamEvent::from_chunk(StreamChunk::error("streaming unsupported"));
+
+        match event {
+            StreamEvent::TextDelta(chunk) => {
+                assert!(chunk.is_final);
+                assert_eq!(chunk.delta, "streaming unsupported");
+            }
+            StreamEvent::Final => panic!("final payload was dropped"),
+            _ => panic!("unexpected event variant"),
+        }
+    }
+
+    #[test]
+    fn stream_event_from_chunk_maps_empty_final_chunk_to_final_event() {
+        let event = StreamEvent::from_chunk(StreamChunk::final_chunk());
+        assert!(matches!(event, StreamEvent::Final));
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent loss of error/reasoning payloads produced by fallback streaming paths by ensuring terminal chunks that carry content are not collapsed into a bare `Final` event.

### Description
- Add two focused regression tests and lock the conversion contract so `StreamChunk` is mapped to `StreamEvent::Final` only when `is_final` is true and both `delta` is empty and `reasoning` is `None`, while final chunks containing payload remain `StreamEvent::TextDelta`.

### Testing
- Attempted to run `cargo test stream_event_from_chunk --lib`, but execution was blocked by crates.io download/network errors (`CONNECT tunnel failed, response 403`), so the new tests are added and ready to run in CI or a networked environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3b327fe008323aafe1cef4342f77e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
