### PR TITLE
ci: Add libasound2-dev dependency to CI workflows

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -9,4 +9,12 @@ ignore = [
     "RUSTSEC-2026-0021",  # WASI http fields panic
     # instant crate unmaintained — transitive dep via nostr; no upstream fix
     "RUSTSEC-2024-0384",
+    # rustls-webpki CRL matching bug via rumqttc — no upstream fix yet
+    "RUSTSEC-2026-0049",
+    # unmaintained transitive deps we cannot easily replace
+    "RUSTSEC-2025-0141",  # bincode via probe-rs
+    "RUSTSEC-2024-0388",  # derivative via extism → wasmtime
+    "RUSTSEC-2025-0057",  # fxhash via extism → wasmtime
+    "RUSTSEC-2025-0134",  # rustls-pemfile — latest version, no replacement available
+    "RUSTSEC-2025-0119",  # number_prefix via indicatif — cosmetic dep
 ]

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -180,7 +180,7 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
 
       - name: Install system dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y libudev-dev
+        run: sudo apt-get update -qq && sudo apt-get install -y libudev-dev libasound2-dev
 
       - name: Ensure web/dist placeholder exists
         run: mkdir -p web/dist && touch web/dist/.gitkeep

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -51,7 +51,7 @@ jobs:
               if: matrix.install_libudev
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y --no-install-recommends libudev-dev pkg-config
+                  sudo apt-get install -y --no-install-recommends libudev-dev libasound2-dev pkg-config
 
             - name: Check feature combination
               run: cargo check --locked ${{ matrix.args }}

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,10 @@ ignore = [
     { id = "RUSTSEC-2026-0006", reason = "wasmtime segfault via extism; awaiting extism upgrade" },
     { id = "RUSTSEC-2026-0020", reason = "WASI resource exhaustion via extism; awaiting extism upgrade" },
     { id = "RUSTSEC-2026-0021", reason = "WASI http fields panic via extism; awaiting extism upgrade" },
+    # rustls-webpki CRL matching bug — transitive via rumqttc; no upstream fix yet
+    { id = "RUSTSEC-2026-0049", reason = "rustls-webpki CRL bug via rumqttc; awaiting rumqttc upgrade" },
+    # rustls-pemfile unmaintained — latest version 2.2.0, no replacement available
+    { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained; latest version, no alternative" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

**Commit 1 — CI build fix:**
- Add `libasound2-dev` to system dependencies in `ci-run.yml` and `feature-matrix.yml` workflows
- Fixes `cargo check --all-features --locked` failure caused by missing ALSA development library required by `voice-wake` feature (`cpal` -> `alsa-sys`)

**Commit 2 — Security audit fix:**
- Add missing advisory ignores to `.cargo/audit.toml` and `deny.toml`
- RUSTSEC-2026-0049: `rustls-webpki` CRL matching bug (transitive via `rumqttc`, no upstream fix)
- RUSTSEC-2025-0134: `rustls-pemfile` unmaintained (latest version 2.2.0, no replacement)
- Align `audit.toml` ignore list with `deny.toml` for all known transitive advisory entries

## Validation Evidence (required)

- `cargo fmt --all -- --check` — pass
- `cargo clippy --all-targets -- -D warnings` — pass
- `cargo test` — pass (compiles and runs)
- `cargo audit` — pass (exit 0, all advisories ignored with documented reasons)
- `cargo deny check licenses sources` — pass
- `cargo deny check` — pass (advisories ok, bans ok, licenses ok, sources ok)
- `ruff check .` — pass

## Security Impact (required)

- **Risk**: Low
- **Mitigation**: Advisory ignores are for transitive dependencies with no upstream fix. Each ignore has a documented reason. No new code paths or permissions introduced.
- `RUSTSEC-2026-0049` (rustls-webpki CRL bug): only affects CRL Distribution Point matching in `rumqttc`'s TLS stack; MQTT channel does not use CRL-based certificate revocation.
- `RUSTSEC-2025-0134` (rustls-pemfile unmaintained): PEM parsing crate, latest version, no known vulnerability — just unmaintained status.

## Privacy and Data Hygiene (required)

- **Status**: No privacy impact. No sensitive data added or exposed. Changes are CI-infrastructure and audit-config only.

## Rollback Plan (required)

- **Rollback**: Revert either commit independently. Commit 1 reverts to the broken `--all-features` CI state. Commit 2 reverts to failing `cargo audit` / `cargo deny` checks.

## Non-goals

- Does not change any Rust source code or feature flags
- Does not upgrade `rumqttc` (0.25.1 still pins vulnerable `rustls-webpki` 0.102.8)

## Workflow files changed

- `.github/workflows/ci-run.yml` — added `libasound2-dev` to apt-get install
- `.github/workflows/feature-matrix.yml` — added `libasound2-dev` to apt-get install