### PR TITLE
Unblock CI collection and 32-bit MQTT builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5207,6 +5207,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5214,6 +5223,7 @@ checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -6239,6 +6249,7 @@ dependencies = [
  "matrix-sdk",
  "mime_guess",
  "nanohtml2text",
+ "native-tls",
  "nostr-sdk",
  "nusb",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,10 @@ async-trait = "0.1"
 # HMAC-SHA256 (Zhipu/GLM JWT auth)
 ring = "0.17"
 
+# Unify features for rumqttc's native-tls backend so cross-target CI can build
+# without relying on a target-specific OpenSSL installation.
+native-tls = { version = "0.2.18", features = ["vendored"] }
+
 # Protobuf encode/decode (Lark WS frame codec, WhatsApp storage)
 prost = { version = "0.14", default-features = false, features = ["derive"], optional = true }
 

--- a/hello_os_executable.py
+++ b/hello_os_executable.py
@@ -1,0 +1,3 @@
+"""Backward-compatible wrapper for :mod:`data.hello_os.hello_os_executable`."""
+
+from data.hello_os.hello_os_executable import *  # noqa: F403

--- a/james_library/services/__init__.py
+++ b/james_library/services/__init__.py
@@ -1,17 +1,30 @@
-"""Background services and external integrations for R.A.I.N. Lab."""
+"""Background services and external integrations for R.A.I.N. Lab.
 
-from . import (
-    external_integrations,
-    kairos_dreamer,
-    openclaw_service,
-    tts_module,
-    voice_activation,
-)
+Some service modules depend on optional local AI stacks that are not required by
+all callers. Resolve service attributes lazily so importing a lightweight
+service does not eagerly pull in heavyweight optional dependencies.
+"""
 
-__all__ = [
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+_SERVICE_MODULES = [
     "external_integrations",
     "kairos_dreamer",
     "openclaw_service",
     "tts_module",
     "voice_activation",
 ]
+
+__all__ = _SERVICE_MODULES
+
+
+def __getattr__(name: str) -> ModuleType:
+    """Load service modules on demand."""
+    if name in _SERVICE_MODULES:
+        module = import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Lazy-load james_library.services so test collection does not import optional AI dependencies through unrelated service entry points, add the missing hello_os_executable compatibility wrapper expected by Python tests, and enable vendored OpenSSL for the native-tls MQTT backend so the 32-bit Linux check can cross-compile.

Constraint: The repo has optional Python and TLS backends that CI imports/builds in narrower contexts than local full-stack environments
Rejected: Add langchain_openai and its transitive stack to baseline test dependencies | unrelated weight for tests that only need lightweight service modules
Rejected: Revert the native-tls backend switch | would re-open the rustls-webpki advisory path we just closed
Confidence: medium
Scope-risk: narrow
Reversibility: clean
Directive: Keep package __init__ files import-safe so tests and tooling can load narrow modules without full optional stacks
Tested: cargo check --lib
Tested: cargo check --locked --lib
Tested: direct imports of james_library.bootstrap.deploy, james_library.services.external_integrations, james_library.services.openclaw_service, and hello_os_executable from a clean working directory
Not-tested: Full GitHub Actions matrix after this commit
Not-tested: Local pytest run in this workspace because untracked root shadow packages alter import resolution

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`main` for all contributions):
- Problem:
- Why it matters:
- What changed:
- What did **not** change (scope boundary):

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`):
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Quality Delta (required for medium/high risk changes)

- Quality delta required? (`Yes/No`):
- Expected panic count impact (production path):
- Expected unwrap count impact (production path):
- Expected flaky test rate impact:
- Expected mean PR size impact (if stacked/split work):
- Expected critical-path test coverage impact:
- If any metric regresses, justify why and note containment/rollback:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use R.A.I.N./project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Mitigation:

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
