### PR TITLE
fix(python): lock down shell and file tool boundaries

### DIFF
--- a/python/R.A.I.N._tools/__init__.py
+++ b/python/R.A.I.N._tools/__init__.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import shlex
+import subprocess
+from pathlib import Path
 from typing import Any, Callable, TypeVar
 
 T = TypeVar("T", bound=Callable[..., Any])
-
 
 def tool(name: str | None = None, description: str | None = None) -> Callable[[T], T]:
     """Decorator to mark a function as a R.A.I.N. tool."""
@@ -20,7 +23,6 @@ def tool(name: str | None = None, description: str | None = None) -> Callable[[T
 
     return decorator
 
-
 class ShellTool:
     """Shell execution tool."""
 
@@ -33,12 +35,35 @@ class ShellTool:
                 "ShellTool.ainvoke cannot be called from an active event loop. "
                 "Use agent.ainvoke() instead."
             )
-        import subprocess
+        if os.getenv("RAIN_TOOLS_ENABLE_SHELL") != "1":
+            return "Error: shell tool is disabled by default. Set RAIN_TOOLS_ENABLE_SHELL=1 to enable."
 
         command = input.get("command", "")
-        result = subprocess.run(command, shell=True, capture_output=True, text=True)
+        if not isinstance(command, str) or not command.strip():
+            return "Error: command must be a non-empty string"
+
+        try:
+            argv = shlex.split(command)
+        except ValueError as exc:
+            return f"Error: invalid command: {exc}"
+
+        result = subprocess.run(argv, shell=False, capture_output=True, text=True)
         return result.stdout or result.stderr
 
+def _workspace_root() -> Path:
+    return Path(os.getenv("RAIN_TOOLS_WORKSPACE", os.getcwd())).resolve()
+
+def _resolve_workspace_path(raw_path: Any) -> Path:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise ValueError("path must be a non-empty string")
+
+    base = _workspace_root()
+    candidate = Path(raw_path)
+    candidate = candidate if candidate.is_absolute() else (base / candidate)
+    resolved = candidate.resolve()
+
+    resolved.relative_to(base)
+    return resolved
 
 class FileReadTool:
     """File read tool."""
@@ -47,16 +72,16 @@ class FileReadTool:
     description = "Read the contents of a file."
 
     async def ainvoke(self, input: dict[str, Any]) -> str:
-        from pathlib import Path
-
-        path = Path(input.get("path", ""))
+        try:
+            path = _resolve_workspace_path(input.get("path", ""))
+        except ValueError as exc:
+            return f"Error: {exc}"
         if not path.exists():
             return f"Error: file not found: {path}"
         try:
             return path.read_text(encoding="utf-8", errors="ignore")
         except Exception as e:
             return f"Error reading file: {e}"
-
 
 class FileWriteTool:
     """File write tool."""
@@ -65,9 +90,10 @@ class FileWriteTool:
     description = "Write content to a file."
 
     async def ainvoke(self, input: dict[str, Any]) -> str:
-        from pathlib import Path
-
-        path = Path(input.get("path", ""))
+        try:
+            path = _resolve_workspace_path(input.get("path", ""))
+        except ValueError as exc:
+            return f"Error: {exc}"
         content = input.get("content", "")
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -75,7 +101,6 @@ class FileWriteTool:
             return f"Successfully wrote to {path}"
         except Exception as e:
             return f"Error writing file: {e}"
-
 
 class Agent:
     """Simple agent wrapper."""
@@ -94,17 +119,14 @@ class Agent:
         # Stub implementation — real LangGraph agent in full package
         return f"Agent(model={self.model}, tools={len(self.tools)})"
 
-
 def create_agent(tools: list[Any], model: str, api_key: str) -> Agent:
     """Create a R.A.I.N. agent with the given tools."""
     return Agent(tools=tools, model=model, api_key=api_key)
-
 
 # Tool singletons
 shell = ShellTool()
 file_read = FileReadTool()
 file_write = FileWriteTool()
-
 
 __all__ = [
     "tool",


### PR DESCRIPTION
### Motivation
- Close a critical security regression where `ShellTool` executed untrusted commands with `shell=True` and file tools read/write arbitrary host paths without workspace/allowlist checks. 
- Enforce secure-by-default behavior for the Python stub package used by agents that may consume untrusted prompts.

### Description
- Disable shell execution by default and require explicit opt-in via the `RAIN_TOOLS_ENABLE_SHELL=1` environment variable to reduce accidental RCE exposure. 
- Replace `subprocess.run(..., shell=True)` with parsed argument execution using `shlex.split(...)` and `subprocess.run(..., shell=False)` and validate that `command` is a non-empty string. 
- Add `_workspace_root()` and `_resolve_workspace_path()` helpers and apply them to `FileReadTool` and `FileWriteTool` so file operations are constrained to `RAIN_TOOLS_WORKSPACE` (or the current working directory) and reject invalid inputs. 
- Return explicit error messages for invalid or disallowed inputs so callers fail fast and securely.

### Testing
- `ruff check python/R.A.I.N._tools/__init__.py` passed and `python -m py_compile python/R.A.I.N._tools/__init__.py` succeeded. 
- Running `PYTHONPATH=. pytest -q` in `python/` was attempted but failed due to environment/package test issues (tests raise `ModuleNotFoundError: No module named 'R'` for the `R.A.I.N._tools` import and the test suite expected `pytest-asyncio` which is not present). 
- `cargo fmt --all -- --check` passed while `cargo clippy --all-targets -- -D warnings` and `cargo test` were blocked by network failures downloading crates.io dependencies in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d70d67ab308323bdd25e9f045eb080)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
