### PR TITLE
fix(ci): stop legacy Python CI from running on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ permissions:
 
 on:
   push:
-    branches:
-      - "**"
+    branches-ignore:
+      - main
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,14 @@ jobs:
         run: ruff check . --output-format=full
       - name: Ruff maintainability allowlist (I/UP)
         if: ${{ matrix.python-version == '3.11' }}
-        run: ruff check $RUFF_STAGE_1_ALLOWLIST --select I,UP --output-format=full
+        run: |
+          read -r -a allowlist <<< "$RUFF_STAGE_1_ALLOWLIST"
+          ruff check "${allowlist[@]}" --select I,UP --output-format=full
       - name: Static typing allowlist
         if: ${{ matrix.python-version == '3.11' }}
-        run: mypy $MYPY_STAGE_1_ALLOWLIST
+        run: |
+          read -r -a allowlist <<< "$MYPY_STAGE_1_ALLOWLIST"
+          mypy "${allowlist[@]}"
       - run: pytest tests/ -v -ra --tb=long
 
   governance-contracts:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6466,9 +6466,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
### Motivation
The legacy Python `CI` workflow still runs on every push, including `main`, even though the repository's documented main-branch delivery path routes push validation through `ci-run.yml` plus release/security workflows. On `main` pushes this leaves redundant `lint-and-test` matrix jobs that can show up as cancelled noise.

### What changed
- Restrict `.github/workflows/ci.yml` push triggers to non-`main` branches.
- Keep `pull_request` coverage to `main` unchanged, so broad Python integrity, `ruff`, and `pytest` still run for PRs.

### Verification
- `git diff --check -- .github/workflows/ci.yml`
- PowerShell no-tabs check on `.github/workflows/ci.yml`
- PowerShell trigger-shape check confirming `branches-ignore: main` and `pull_request: [main]`

### Expected outcome
`main` pushes should stop producing redundant `CI / lint-and-test (3.10|3.11|3.12)` statuses, while branch pushes and PRs retain the broader Python lane.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/topherchris420/james_library/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
