### PR TITLE
Sharpen the default product path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     env:
       RUFF_STAGE_1_ALLOWLIST: >-
+        archive_pipeline.py
         rain_lab.py
         rain_preflight_check.py
         tools.py

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tokio-stream = { version = "0.1.18", default-features = false, features = ["fs",
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "multipart", "stream", "socks"] }
 
 # Matrix client + E2EE decryption
-matrix-sdk = { version = "0.16", optional = true, default-features = false, features = ["e2e-encryption", "rustls-tls", "markdown", "sqlite"] }
+matrix-sdk = { version = "0.16.1", optional = true, default-features = false, features = ["e2e-encryption", "rustls-tls", "markdown", "sqlite"] }
 
 # Serialization
 serde = { version = "1.0", default-features = false, features = ["derive"] }
@@ -182,7 +182,7 @@ tokio-rustls = "0.26.4"
 webpki-roots = "1.0.6"
 
 # email
-lettre = { version = "0.11.19", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"] }
+lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"] }
 mail-parser = "0.11.2"
 async-imap = { version = "0.11",features = ["runtime-tokio"], default-features = false }
 

--- a/Justfile
+++ b/Justfile
@@ -21,6 +21,14 @@ lint:
 test:
     cargo test --locked
 
+# Run the default no-setup demo path
+demo:
+    python rain_lab.py --mode demo --preset startup-debate
+
+# Validate the local R.A.I.N. Lab environment
+validate:
+    python rain_lab.py --mode validate
+
 # Run only unit tests (faster)
 test-lib:
     cargo test --lib

--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ James is the assistant inside the R.A.I.N. Lab.
 
 ---
 
+## Default Path
+
+No setup: [rainlabteam.vercel.app](https://rainlabteam.vercel.app/)
+
+Local start:
+
+```bash
+python rain_lab.py
+```
+
+That launcher is the stable product path. Hardware, messaging channels, web
+deployment, TRIBE v2 sidecars, archive tooling, and provider-specific adapters
+are opt-in extensions, not prerequisites for a first successful run.
+
+For the maintainer boundary between core, extension, and experimental work, see
+[`docs/project/product-boundary.md`](docs/project/product-boundary.md).
+
+---
+
 ## What It Does
 
 - Turns one research question into a four-agent meeting with distinct constraints

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -32,6 +32,10 @@ Integrations such as Matrix, Lark, Nostr, WhatsApp Web, hardware, and
 experimental workflow automation are opt-in extensions. Treat them as add-ons,
 not the baseline product.
 
+If you are deciding whether a file, script, or integration belongs in the
+default path, use the product boundary:
+[`docs/project/product-boundary.md`](docs/project/product-boundary.md).
+
 If you need the full support boundary, see
 [`docs/project/stability-tiers.md`](docs/project/stability-tiers.md).
 

--- a/archive_pipeline.py
+++ b/archive_pipeline.py
@@ -28,10 +28,9 @@ import shutil
 import subprocess
 import sys
 import tarfile
-from functools import lru_cache
+from collections.abc import Iterable, Sequence
+from functools import cache, lru_cache
 from pathlib import Path
-from typing import Iterable, Sequence
-
 
 ARCHIVE_NAME = "james_library_archive.tar.gz"
 CHECKSUM_NAME = "checksum.txt"
@@ -357,8 +356,7 @@ def run_command(
         result = subprocess.run(
             [str(part) for part in command],
             cwd=str(cwd) if cwd else None,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
             encoding="utf-8",
             errors="replace",
@@ -802,7 +800,7 @@ def poly_multiply(left: Sequence[int], right: Sequence[int]) -> list[int]:
     return result
 
 
-@lru_cache(maxsize=None)
+@cache
 def rs_generator(degree: int) -> tuple[int, ...]:
     exp, _log = gf_tables()
     coefficients = [1]

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -137,6 +137,7 @@ Last refreshed: **February 18, 2026**.
 ### 7) Project Status & Snapshot
 
 - [maintainers/README.md](maintainers/README.md)
+- [project/product-boundary.md](project/product-boundary.md)
 - [project/stability-tiers.md](project/stability-tiers.md)
 - [project-triage-snapshot-2026-02-18.md](maintainers/project-triage-snapshot-2026-02-18.md)
 - [docs-inventory.md](maintainers/docs-inventory.md)

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -3,6 +3,7 @@
 Project-level orientation docs:
 
 - Root README: [`../../README.md`](../../README.md)
+- Product boundary: [`product-boundary.md`](product-boundary.md)
 - Scope and stability tiers: [`stability-tiers.md`](stability-tiers.md)
 - Production readiness gates: [`../PRODUCTION_READINESS.md`](../PRODUCTION_READINESS.md)
 - Godot blueprint notes: [`../GODOT_SCENE_THEME_BLUEPRINT.md`](../GODOT_SCENE_THEME_BLUEPRINT.md)

--- a/docs/project/product-boundary.md
+++ b/docs/project/product-boundary.md
@@ -1,0 +1,64 @@
+# Product Boundary
+
+R.A.I.N. Lab is a local-first research assistant that runs a structured expert-panel workflow over private context. The default product experience is the launcher plus the stable runtime needed to ask a research question, run the James/Jasmine/Luca/Elena meeting, preserve the transcript, and review the result offline.
+
+## Stable Core
+
+The stable core is the path a new user should be able to trust first:
+
+- `python rain_lab.py`
+- `python rain_lab.py --mode demo --preset startup-debate`
+- `python rain_lab.py --mode validate`
+- `python rain_lab.py --mode chat --topic "..."`
+- The Rust `rain` runtime and its default provider, tool, memory, security, and gateway contracts
+- Installer entry points: `INSTALL_RAIN.cmd`, `INSTALL_RAIN.ps1`, and `install.sh`
+- Local meeting artifacts under `meeting_archives/`
+
+Core changes need user-facing docs, tests or smoke coverage, and CI verification.
+
+## Opt-In Extensions
+
+Extensions are supported, but they should not be required for the default path:
+
+- Messaging channels such as Slack, Telegram, Matrix, Nostr, Lark, and email
+- Hardware and firmware integrations
+- TRIBE v2 and other sidecar services
+- Web dashboard and deployment assets
+- Plugin examples and custom provider integrations
+
+Extension changes should keep their setup isolated, avoid surprising network calls, and preserve the default local-only flow.
+
+## Experiments And Archive Material
+
+Experimental or archival assets may stay in the repository when they are useful for preservation, demos, or research continuity, but they must be labeled as non-core. Large generated files, benchmark data, prototype scripts, and research snapshots should not become default startup dependencies.
+
+If an experiment becomes user-facing, promote it by adding:
+
+- a documented entry point,
+- a test or smoke check,
+- ownership notes,
+- and a clear failure mode when optional dependencies are absent.
+
+## Out Of Scope For The Core Path
+
+The core product should not require:
+
+- cloud inference,
+- hosted telemetry,
+- hardware devices,
+- web deployment,
+- social or messaging channel credentials,
+- or external model sidecars.
+
+Those capabilities are valuable extensions. They are not prerequisites for the first successful run.
+
+## Naming Rule
+
+Use these names consistently:
+
+- **R.A.I.N. Lab**: the product experience.
+- **James**: the lead assistant in the research meeting.
+- **James Library**: the repository and Python workflow collection.
+- **rain**: the Rust binary/runtime crate.
+- **ZeroClaw**: legacy/runtime branding used only where existing compatibility requires it.
+

--- a/james_library/utilities/session_replay.py
+++ b/james_library/utilities/session_replay.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shlex
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -13,7 +16,7 @@ from james_library.utilities.session_eval import evaluate_artifacts_against_gold
 
 
 DEFAULT_COMMAND_TEMPLATE = (
-    'python rain_lab.py --mode chat --topic "{topic}" --turns 4 --ui off --library "{library_path}"'
+    '{python} rain_lab.py --mode chat --topic "{topic}" --turns 4 --ui off --library "{library_path}"'
 )
 
 
@@ -29,8 +32,16 @@ def _default_report_dir(library_path: Path) -> Path:
     return library_path / "benchmark_data" / "session_eval_reports"
 
 
+def _quote_shell_arg(value: str | Path) -> str:
+    text = str(value)
+    if os.name == "nt":
+        return subprocess.list2cmdline([text])
+    return shlex.quote(text)
+
+
 def _format_command(command_template: str, *, artifact_dir: Path, case_id: str, topic: str, library_path: Path) -> str:
     return command_template.format(
+        python=_quote_shell_arg(sys.executable),
         artifact_dir=str(artifact_dir),
         case_id=case_id,
         topic=topic.replace('"', "'"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ ignore_missing_imports = true
 ruff_stage_0_rules = ["E", "F", "W"]
 ruff_stage_1_rules = ["I", "UP"]
 ruff_stage_1_allowlist = [
+    "archive_pipeline.py",
     "rain_lab.py",
     "rain_preflight_check.py",
     "tools.py",

--- a/tests/test_session_replay.py
+++ b/tests/test_session_replay.py
@@ -96,7 +96,7 @@ def test_run_replay_executes_cases_collects_artifacts_and_writes_report(tmp_path
     )
 
     command_template = (
-        f'python "{emitter_path}" --artifact-dir "{{artifact_dir}}" '
+        f'{{python}} "{emitter_path}" --artifact-dir "{{artifact_dir}}" '
         f'--case-id "{{case_id}}" --topic "{{topic}}"'
     )
     result = run_replay(


### PR DESCRIPTION
## Summary
- Add a product-boundary doc that separates the stable R.A.I.N. Lab core path from opt-in extensions and experiments.
- Make the README and START_HERE default path clearer, and add `just demo` / `just validate` maintainer shortcuts.
- Align direct Rust dependency manifests with the patched security baseline and expand staged Ruff maintainability coverage to `archive_pipeline.py`.
- Make session replay portable on Windows by formatting `{python}` with the active interpreter and updating the regression test.

## Verification
- `py -m pytest tests -q`
- `uvx ruff check . --output-format=full`
- `uvx ruff check archive_pipeline.py rain_lab.py rain_preflight_check.py tools.py truth_layer.py --select I,UP --output-format=full`
- `py archive_pipeline.py --dry-run`
- `bash scripts/ci/docs_parity_check.sh`
- `cargo check --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo audit`
- `cargo deny check licenses sources`

Not tested locally: `just --list` because `just` is not installed in this Windows environment.
