### PR TITLE
Add response normalization and mobile UI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+# Anchored to repo root: web/src/lib/ is real source, not a build artifact
+/lib/
 lib64/
 parts/
 sdist/

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { LogOut, Settings } from 'lucide-react';
+import { LogOut, Menu, Settings, X } from 'lucide-react';
 import { t } from '@/lib/i18n';
 import { useLocaleContext } from '@/App';
 import { useAuth } from '@/hooks/useAuth';
@@ -19,7 +19,14 @@ const routeTitles: Record<string, string> = {
   '/doctor': 'nav.doctor',
 };
 
-export default function Header() {
+interface HeaderProps {
+  /** Toggles the mobile navigation drawer. */
+  onMenuClick?: () => void;
+  /** Whether the mobile navigation drawer is currently open. */
+  menuOpen?: boolean;
+}
+
+export default function Header({ onMenuClick, menuOpen = false }: HeaderProps) {
   const location = useLocation();
   const { logout } = useAuth();
   const { locale, setAppLocale } = useLocaleContext();
@@ -27,6 +34,11 @@ export default function Header() {
 
   const titleKey = routeTitles[location.pathname] ?? 'nav.dashboard';
   const pageTitle = t(titleKey);
+
+  // Keep the browser tab title in sync with the current page
+  useEffect(() => {
+    document.title = `${pageTitle} · R.A.I.N.`;
+  }, [pageTitle]);
 
   const toggleLanguage = () => {
     // Cycle through: en -> zh -> tr -> en
@@ -36,9 +48,24 @@ export default function Header() {
 
   return (
     <>
-      <header className="h-14 flex items-center justify-between px-6 border-b animate-fade-in" style={{ background: 'var(--pc-bg-surface)', borderColor: 'var(--pc-border)', backdropFilter: 'blur(12px)', }}>
-        {/* Page title */}
-        <h1 className="h-9 leading-9 text-lg font-semibold tracking-tight" style={{ color: 'var(--pc-text-primary)' }}>{pageTitle}</h1>
+      <header className="h-14 flex items-center justify-between px-4 sm:px-6 border-b animate-fade-in" style={{ background: 'var(--pc-bg-surface)', borderColor: 'var(--pc-border)', backdropFilter: 'blur(12px)', }}>
+        <div className="flex items-center gap-2 min-w-0">
+          {/* Mobile navigation toggle */}
+          <button
+            type="button"
+            onClick={onMenuClick}
+            className="lg:hidden h-9 w-9 flex items-center justify-center rounded-xl transition-all shrink-0"
+            style={{ color: 'var(--pc-text-muted)', background: 'transparent', border: 'none', cursor: 'pointer' }}
+            aria-label={menuOpen ? t('nav.close_menu') : t('nav.open_menu')}
+            aria-expanded={menuOpen}
+            aria-controls="app-sidebar"
+          >
+            {menuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
+
+          {/* Page title */}
+          <h1 className="h-9 leading-9 text-lg font-semibold tracking-tight truncate" style={{ color: 'var(--pc-text-primary)' }}>{pageTitle}</h1>
+        </div>
 
         {/* Right-side controls */}
         <div className="flex items-center gap-2 h-9">
@@ -73,6 +100,8 @@ export default function Header() {
               e.currentTarget.style.borderColor = 'var(--pc-border)';
               e.currentTarget.style.color = 'var(--pc-text-secondary)';
             }}
+            aria-label={t('header.switch_language')}
+            title={t('header.switch_language')}
           >
             {locale === 'en' ? 'EN' : locale === 'zh' ? 'ZH' : 'TR'}
           </button>

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,21 +1,49 @@
+import { useEffect, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import SecurityBanner from '@/components/SecurityBanner';
 import Sidebar from '@/components/layout/Sidebar';
 import Header from '@/components/layout/Header';
 import { ErrorBoundary } from '@/App';
+import { t } from '@/lib/i18n';
 
 export default function Layout() {
   const { pathname } = useLocation();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  // Close the mobile drawer whenever the route changes
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [pathname]);
+
+  // Close the mobile drawer on Escape
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setSidebarOpen(false);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [sidebarOpen]);
 
   return (
     <div className="min-h-screen text-white" style={{ background: 'var(--pc-bg-base)' }}>
-      {/* Fixed sidebar */}
-      <Sidebar />
+      {/* Sidebar: fixed column on desktop, slide-in drawer on mobile */}
+      <Sidebar open={sidebarOpen} />
 
-      {/* Main area offset by sidebar width (240px / w-60) */}
-      <div className="ml-60 flex flex-col flex-1 min-w-0 h-screen">
+      {/* Overlay behind the mobile drawer */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-[110] bg-black/50 lg:hidden"
+          role="presentation"
+          aria-label={t('nav.close_menu')}
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      {/* Main area offset by sidebar width (240px / w-60) on desktop */}
+      <div className="lg:ml-60 flex flex-col flex-1 min-w-0 h-screen">
         <SecurityBanner />
-        <Header />
+        <Header onMenuClick={() => setSidebarOpen((open) => !open)} menuOpen={sidebarOpen} />
 
         {/* Page content — ErrorBoundary keyed by pathname so the nav shell
             survives a page crash and the boundary resets on route change */}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -27,9 +27,25 @@ const navItems = [
   { to: '/doctor', icon: Stethoscope, labelKey: 'nav.doctor' },
 ];
 
-export default function Sidebar() {
+interface SidebarProps {
+  /** Whether the mobile drawer is open. Ignored on desktop (always visible). */
+  open?: boolean;
+}
+
+export default function Sidebar({ open = false }: SidebarProps) {
   return (
-    <aside className="fixed top-0 left-0 h-screen w-60 flex flex-col border-r" style={{ background: 'var(--pc-bg-base)', borderColor: 'var(--pc-border)' }}>
+    <aside
+      id="app-sidebar"
+      aria-label={t('nav.main_navigation')}
+      className={[
+        // Above the SecurityBanner (z-[100]) so the mobile drawer is never obscured
+        'fixed top-0 left-0 h-screen w-60 flex flex-col border-r z-[120]',
+        'transition-transform duration-200 ease-out',
+        'lg:translate-x-0',
+        open ? 'translate-x-0' : '-translate-x-full',
+      ].join(' ')}
+      style={{ background: 'var(--pc-bg-base)', borderColor: 'var(--pc-border)' }}
+    >
       {/* Logo / Title */}
       <div className="flex items-center gap-3 px-4 py-4 border-b h-14" style={{ borderColor: 'var(--pc-border)' }}>
         <div className="relative shrink-0">

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -97,6 +97,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     removeToken();
     setTokenState(null);
     setAuthenticated(false);
+    // Logout is a privacy boundary: let session-scoped in-memory stores
+    // (e.g. cached chat history) drop their data before a new pairing.
+    window.dispatchEvent(new Event('R.A.I.N.-logout'));
   }, []);
 
   const value: AuthState = {

--- a/web/src/hooks/useDraft.ts
+++ b/web/src/hooks/useDraft.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext, useCallback, useRef } from 'react';
+import { createContext, useContext, useCallback, useEffect, useRef } from 'react';
 
 /**
  * In-memory draft store that survives component unmounts but not page reloads.
@@ -19,6 +19,14 @@ export const DraftContext = createContext<DraftContextType>({
 
 export function useDraftStore(): DraftContextType {
   const store = useRef<Map<string, string>>(new Map());
+
+  // Logout is a privacy boundary: unsent drafts belong to the session that
+  // typed them and must not leak into the next pairing.
+  useEffect(() => {
+    const handler = () => store.current.clear();
+    window.addEventListener('R.A.I.N.-logout', handler);
+    return () => window.removeEventListener('R.A.I.N.-logout', handler);
+  }, []);
 
   const getDraft = useCallback((key: string): string => {
     return store.current.get(key) ?? '';

--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -1,0 +1,119 @@
+import { normalizeCost, normalizeStatus } from '../api';
+
+describe('normalizeStatus', () => {
+  it('returns safe defaults for an empty response', () => {
+    const status = normalizeStatus({});
+
+    expect(status.provider).toBeNull();
+    expect(status.model).toBe('');
+    expect(status.uptime_seconds).toBe(0);
+    expect(status.gateway_port).toBe(0);
+    expect(status.paired).toBe(false);
+    expect(status.channels).toEqual({});
+    expect(status.health.components).toEqual({});
+  });
+
+  it('returns safe defaults for non-object payloads', () => {
+    for (const junk of [null, undefined, 'oops', 42, [1, 2, 3]]) {
+      const status = normalizeStatus(junk);
+      expect(status.channels).toEqual({});
+      expect(status.health.components).toEqual({});
+    }
+  });
+
+  it('preserves a well-formed payload', () => {
+    const status = normalizeStatus({
+      provider: 'openai',
+      model: 'test-model',
+      temperature: 0.7,
+      uptime_seconds: 3600,
+      gateway_port: 8080,
+      locale: 'en',
+      memory_backend: 'sqlite',
+      paired: true,
+      channels: { telegram: true, discord: false },
+      health: {
+        pid: 123,
+        updated_at: '2026-01-01T00:00:00Z',
+        uptime_seconds: 3600,
+        components: {
+          gateway: {
+            status: 'ok',
+            updated_at: '2026-01-01T00:00:00Z',
+            last_ok: '2026-01-01T00:00:00Z',
+            last_error: null,
+            restart_count: 2,
+          },
+        },
+      },
+    });
+
+    expect(status.provider).toBe('openai');
+    expect(status.channels).toEqual({ telegram: true, discord: false });
+    expect(status.health.components.gateway?.status).toBe('ok');
+    expect(status.health.components.gateway?.restart_count).toBe(2);
+  });
+
+  it('coerces malformed nested fields instead of crashing', () => {
+    const status = normalizeStatus({
+      uptime_seconds: 'not-a-number',
+      gateway_port: NaN,
+      channels: { telegram: 'yes', discord: true },
+      health: {
+        components: {
+          gateway: { status: 42, restart_count: 'many' },
+          broken: null,
+        },
+      },
+    });
+
+    expect(status.uptime_seconds).toBe(0);
+    expect(status.gateway_port).toBe(0);
+    // Non-boolean channel values degrade to inactive
+    expect(status.channels).toEqual({ telegram: false, discord: true });
+    expect(status.health.components.gateway?.status).toBe('unknown');
+    expect(status.health.components.gateway?.restart_count).toBe(0);
+    expect(status.health.components.broken?.status).toBe('unknown');
+  });
+});
+
+describe('normalizeCost', () => {
+  it('returns zeroed totals for an empty response', () => {
+    const cost = normalizeCost({});
+
+    expect(cost.session_cost_usd).toBe(0);
+    expect(cost.daily_cost_usd).toBe(0);
+    expect(cost.monthly_cost_usd).toBe(0);
+    expect(cost.total_tokens).toBe(0);
+    expect(cost.request_count).toBe(0);
+    expect(cost.by_model).toEqual({});
+  });
+
+  it('preserves a well-formed payload', () => {
+    const cost = normalizeCost({
+      session_cost_usd: 0.5,
+      daily_cost_usd: 1.25,
+      monthly_cost_usd: 10,
+      total_tokens: 5000,
+      request_count: 42,
+      by_model: {
+        'test-model': { model: 'test-model', cost_usd: 10, total_tokens: 5000, request_count: 42 },
+      },
+    });
+
+    expect(cost.session_cost_usd).toBe(0.5);
+    expect(cost.by_model['test-model']?.cost_usd).toBe(10);
+  });
+
+  it('coerces malformed model stats and fills a missing model name from the key', () => {
+    const cost = normalizeCost({
+      total_tokens: null,
+      by_model: { 'test-model': { cost_usd: 'free' } },
+    });
+
+    expect(cost.total_tokens).toBe(0);
+    expect(cost.by_model['test-model']?.model).toBe('test-model');
+    expect(cost.by_model['test-model']?.cost_usd).toBe(0);
+    expect(cost.by_model['test-model']?.total_tokens).toBe(0);
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -8,7 +8,9 @@ import type {
   MemoryEntry,
   CostSummary,
   CliTool,
+  ComponentHealth,
   HealthSnapshot,
+  ModelStats,
 } from '../types/api';
 import { clearToken, getToken, setToken } from './auth';
 import { basePath } from './basePath';
@@ -75,6 +77,97 @@ function unwrapField<T>(value: T | Record<string, T>, key: string): T {
 }
 
 // ---------------------------------------------------------------------------
+// Response normalization
+//
+// The gateway and the web bundle can run different versions, and error shims
+// or proxies may return partial JSON. Responses rendered directly by pages are
+// coerced to their declared shape here, at the boundary, so missing or
+// malformed fields degrade to safe defaults instead of crashing render.
+// ---------------------------------------------------------------------------
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function asStringOrNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+export function normalizeStatus(data: unknown): StatusResponse {
+  const raw = asRecord(data);
+  const rawHealth = asRecord(raw.health);
+
+  const components: Record<string, ComponentHealth> = {};
+  for (const [name, value] of Object.entries(asRecord(rawHealth.components))) {
+    const comp = asRecord(value);
+    components[name] = {
+      status: asString(comp.status, 'unknown'),
+      updated_at: asString(comp.updated_at),
+      last_ok: asStringOrNull(comp.last_ok),
+      last_error: asStringOrNull(comp.last_error),
+      restart_count: asNumber(comp.restart_count),
+    };
+  }
+
+  const channels: Record<string, boolean> = {};
+  for (const [name, active] of Object.entries(asRecord(raw.channels))) {
+    channels[name] = active === true;
+  }
+
+  return {
+    provider: asStringOrNull(raw.provider),
+    model: asString(raw.model),
+    temperature: asNumber(raw.temperature),
+    uptime_seconds: asNumber(raw.uptime_seconds),
+    gateway_port: asNumber(raw.gateway_port),
+    locale: asString(raw.locale),
+    memory_backend: asString(raw.memory_backend),
+    paired: raw.paired === true,
+    channels,
+    health: {
+      pid: asNumber(rawHealth.pid),
+      updated_at: asString(rawHealth.updated_at),
+      uptime_seconds: asNumber(rawHealth.uptime_seconds),
+      components,
+    },
+  };
+}
+
+export function normalizeCost(data: unknown): CostSummary {
+  const raw = asRecord(data);
+
+  const by_model: Record<string, ModelStats> = {};
+  for (const [name, value] of Object.entries(asRecord(raw.by_model))) {
+    const stats = asRecord(value);
+    by_model[name] = {
+      model: asString(stats.model, name),
+      cost_usd: asNumber(stats.cost_usd),
+      total_tokens: asNumber(stats.total_tokens),
+      request_count: asNumber(stats.request_count),
+    };
+  }
+
+  return {
+    session_cost_usd: asNumber(raw.session_cost_usd),
+    daily_cost_usd: asNumber(raw.daily_cost_usd),
+    monthly_cost_usd: asNumber(raw.monthly_cost_usd),
+    total_tokens: asNumber(raw.total_tokens),
+    request_count: asNumber(raw.request_count),
+    by_model,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Pairing
 // ---------------------------------------------------------------------------
 
@@ -119,7 +212,7 @@ export async function getPublicHealth(): Promise<{ require_pairing: boolean; pai
 // ---------------------------------------------------------------------------
 
 export function getStatus(): Promise<StatusResponse> {
-  return apiFetch<StatusResponse>('/api/status');
+  return apiFetch<unknown>('/api/status').then(normalizeStatus);
 }
 
 export function getHealth(): Promise<HealthSnapshot> {
@@ -287,7 +380,7 @@ export function deleteMemory(key: string): Promise<void> {
 
 export function getCost(): Promise<CostSummary> {
   return apiFetch<CostSummary | { cost: CostSummary }>('/api/cost').then((data) =>
-    unwrapField(data, 'cost'),
+    normalizeCost(unwrapField(data, 'cost')),
   );
 }
 

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -20,6 +20,10 @@ const translations: Record<Locale, Record<string, string>> = {
     'nav.cost': '成本追踪',
     'nav.logs': '日志',
     'nav.doctor': '诊断',
+    'nav.main_navigation': '主导航',
+    'nav.open_menu': '打开导航菜单',
+    'nav.close_menu': '关闭导航菜单',
+    'header.switch_language': '切换语言',
 
     // Dashboard
     'dashboard.title': '仪表盘',
@@ -350,6 +354,10 @@ const translations: Record<Locale, Record<string, string>> = {
     'nav.cost': 'Cost Tracker',
     'nav.logs': 'Logs',
     'nav.doctor': 'Doctor',
+    'nav.main_navigation': 'Main navigation',
+    'nav.open_menu': 'Open navigation menu',
+    'nav.close_menu': 'Close navigation menu',
+    'header.switch_language': 'Switch language',
 
     // Dashboard
     'dashboard.title': 'Dashboard',
@@ -680,6 +688,10 @@ const translations: Record<Locale, Record<string, string>> = {
     'nav.cost': 'Maliyet Takibi',
     'nav.logs': 'Kayıtlar',
     'nav.doctor': 'Doktor',
+    'nav.main_navigation': 'Ana gezinme',
+    'nav.open_menu': 'Gezinme menüsünü aç',
+    'nav.close_menu': 'Gezinme menüsünü kapat',
+    'header.switch_language': 'Dili değiştir',
 
     // Dashboard
     'dashboard.title': 'Kontrol Paneli',

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -15,24 +15,38 @@ interface ChatMessage {
 
 const DRAFT_KEY = 'agent-chat';
 
+// In-memory chat history that survives route changes (like drafts, it is
+// intentionally not persisted across page reloads).
+let cachedMessages: ChatMessage[] = [];
+
 export default function AgentChat() {
   const { draft, saveDraft, clearDraft } = useDraft(DRAFT_KEY);
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [messages, setMessages] = useState<ChatMessage[]>(() => cachedMessages);
   const [input, setInput] = useState(draft);
   const [typing, setTyping] = useState(false);
+  const [streamingText, setStreamingText] = useState('');
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const wsRef = useRef<WebSocketClient | null>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const pendingContentRef = useRef('');
+  // Autoscroll only while the user is at (or near) the bottom, so scrolling
+  // up to read history is never interrupted by incoming messages.
+  const stickToBottomRef = useRef(true);
 
   // Persist draft to in-memory store so it survives route changes
   useEffect(() => {
     saveDraft(input);
   }, [input, saveDraft]);
+
+  // Keep the module-level history cache in sync
+  useEffect(() => {
+    cachedMessages = messages;
+  }, [messages]);
 
   useEffect(() => {
     const ws = new WebSocketClient();
@@ -55,6 +69,7 @@ export default function AgentChat() {
         case 'chunk':
           setTyping(true);
           pendingContentRef.current += msg.content ?? '';
+          setStreamingText(pendingContentRef.current);
           break;
 
         case 'message':
@@ -72,6 +87,7 @@ export default function AgentChat() {
             ]);
           }
           pendingContentRef.current = '';
+          setStreamingText('');
           setTyping(false);
           break;
         }
@@ -112,6 +128,7 @@ export default function AgentChat() {
           ]);
           setTyping(false);
           pendingContentRef.current = '';
+          setStreamingText('');
           break;
       }
     };
@@ -121,16 +138,42 @@ export default function AgentChat() {
 
     return () => {
       ws.disconnect();
+      // Unmounting closes the socket, so a mid-stream reply will never get its
+      // 'done' frame. Commit the partial text to the cached history instead of
+      // silently dropping it.
+      if (pendingContentRef.current) {
+        cachedMessages = [
+          ...cachedMessages,
+          {
+            id: generateUUID(),
+            role: 'agent',
+            content: pendingContentRef.current,
+            timestamp: new Date(),
+          },
+        ];
+        pendingContentRef.current = '';
+      }
     };
   }, []);
 
+  const handleScroll = () => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    stickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+  };
+
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages, typing]);
+    if (!stickToBottomRef.current) return;
+    // Instant scroll while streaming (chunks arrive fast), smooth otherwise
+    messagesEndRef.current?.scrollIntoView({ behavior: streamingText ? 'auto' : 'smooth' });
+  }, [messages, typing, streamingText]);
 
   const handleSend = () => {
     const trimmed = input.trim();
     if (!trimmed || !wsRef.current?.connected) return;
+
+    // Sending a message always snaps the view back to the latest content
+    stickToBottomRef.current = true;
 
     setMessages((prev) => [
       ...prev,
@@ -223,7 +266,7 @@ export default function AgentChat() {
       )}
 
       {/* Messages area */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div ref={scrollContainerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.length === 0 && (
           <div className="flex flex-col items-center justify-center h-full text-center animate-fade-in" style={{ color: 'var(--pc-text-muted)' }}>
             <div className="h-16 w-16 rounded-3xl flex items-center justify-center mb-4 animate-float" style={{ background: 'var(--pc-accent-glow)' }}>
@@ -288,7 +331,22 @@ export default function AgentChat() {
           </div>
         ))}
 
-        {typing && (
+        {/* Live streaming response — rendered as it arrives */}
+        {streamingText && (
+          <div className="flex items-start gap-3 animate-fade-in">
+            <div className="flex-shrink-0 w-9 h-9 rounded-2xl flex items-center justify-center border" style={{ background: 'var(--pc-bg-elevated)', borderColor: 'var(--pc-border)' }}>
+              <Bot className="h-4 w-4" style={{ color: 'var(--pc-accent)' }} />
+            </div>
+            <div className="max-w-[75%] rounded-2xl px-4 py-3 border" style={{ background: 'var(--pc-bg-elevated)', borderColor: 'var(--pc-border)', color: 'var(--pc-text-primary)' }}>
+              <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+                {streamingText}
+                <span className="inline-block w-0.5 h-4 ml-0.5 align-text-bottom animate-pulse" style={{ background: 'var(--pc-accent)' }} />
+              </p>
+            </div>
+          </div>
+        )}
+
+        {typing && !streamingText && (
           <div className="flex items-start gap-3 animate-fade-in">
             <div className="flex-shrink-0 w-9 h-9 rounded-2xl flex items-center justify-center border" style={{ background: 'var(--pc-bg-elevated)', borderColor: 'var(--pc-border)' }}>
               <Bot className="h-4 w-4" style={{ color: 'var(--pc-accent)' }} />

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -19,6 +19,17 @@ const DRAFT_KEY = 'agent-chat';
 // intentionally not persisted across page reloads).
 let cachedMessages: ChatMessage[] = [];
 
+// Set on logout so an unmount that races the logout event does not re-commit
+// partially streamed content into the (just cleared) cache. Reset on mount.
+let sessionEnded = false;
+
+// Logout is a privacy boundary: a later pairing in the same tab must not see
+// the previous session's conversation.
+window.addEventListener('R.A.I.N.-logout', () => {
+  sessionEnded = true;
+  cachedMessages = [];
+});
+
 export default function AgentChat() {
   const { draft, saveDraft, clearDraft } = useDraft(DRAFT_KEY);
   const [messages, setMessages] = useState<ChatMessage[]>(() => cachedMessages);
@@ -49,6 +60,7 @@ export default function AgentChat() {
   }, [messages]);
 
   useEffect(() => {
+    sessionEnded = false;
     const ws = new WebSocketClient();
 
     ws.onOpen = () => {
@@ -140,8 +152,9 @@ export default function AgentChat() {
       ws.disconnect();
       // Unmounting closes the socket, so a mid-stream reply will never get its
       // 'done' frame. Commit the partial text to the cached history instead of
-      // silently dropping it.
-      if (pendingContentRef.current) {
+      // silently dropping it — unless the session just ended, in which case the
+      // cache was cleared and must stay empty.
+      if (pendingContentRef.current && !sessionEnded) {
         cachedMessages = [
           ...cachedMessages,
           {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -86,14 +86,14 @@ const STATUS_CARDS = [
     icon: Globe,
     accent: "#a78bfa",
     labelKey: "dashboard.gateway_port",
-    getValue: (s: StatusResponse) => `:${s.gateway_port}`,
+    getValue: (s: StatusResponse) => (s.gateway_port ? `:${s.gateway_port}` : "—"),
     getSub: () => "",
   },
   {
     icon: Database,
     accent: "#fbbf24",
     labelKey: "dashboard.memory_backend",
-    getValue: (s: StatusResponse) => s.memory_backend,
+    getValue: (s: StatusResponse) => s.memory_backend || "—",
     getSub: (s: StatusResponse) =>
       `${t("dashboard.paired")}: ${s.paired ? t("dashboard.paired_yes") : t("dashboard.paired_no")}`,
   },


### PR DESCRIPTION
## Summary

- Base branch target (`main` for all contributions): `main`
- Problem: (1) The dashboard crashed into its error boundary when `/api/status` or `/api/cost` returned partial/malformed JSON (gateway/web version skew, error shims). (2) The web shell had no mobile navigation, and Agent Chat buffered streamed replies invisibly, force-scrolled while reading history, and lost the conversation on route change.
- Why it matters: Resilience to version skew is production stability; mobile navigation and live streaming are table-stakes UX for the dashboard.
- What changed:
  - `normalizeStatus()` / `normalizeCost()` coerce API responses to their declared shape at the API boundary; all consumers (Dashboard, Cost, hooks, locale detection) get safe defaults instead of render crashes.
  - Agent Chat renders streamed chunks live, autoscroll only sticks at the bottom, history survives route changes via an in-memory cache, and a reply interrupted mid-stream is committed as a partial message.
  - Logout is treated as a privacy boundary: cached chat history and unsent drafts are cleared on logout, so re-pairing in the same tab cannot see the previous session's conversation (addresses Codex review finding).
  - Responsive shell: sidebar becomes a slide-in drawer on small screens with hamburger toggle, overlay/Escape/route-change dismissal.
  - Browser tab title follows the active page; aria labels for drawer/sidebar/language switcher with new i18n keys.
  - `.gitignore`: anchored the Python-template `lib/` rule to `/lib/` — it was silently ignoring new files under `web/src/lib/` (real source).
- What did **not** change (scope boundary): Rust runtime, gateway API contracts, config schema, security model, provider/channel/tool subsystems.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: M` (auto-managed)
- Scope labels: `dev`
- Module labels: `web: ui`, `web: api`
- Contributor tier label: (auto-managed)
- Auto-label corrections: none

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (web UI + web API client)

## Linked Issue

- Closes: (none)
- Related: (none)

## Validation Evidence (required)

Commands and result summary:

```bash
# Web-only change — Rust toolchain untouched, so cargo gates are covered by CI only
cd web
npm run lint        # eslint: clean
npm test -- --run   # vitest: 16/16 passing (7 new normalization tests)
npm run build       # tsc -b && vite build: success
```

- Evidence provided: Playwright run against the built bundle in Chromium — 26 scenarios covering desktop/mobile layout, drawer lifecycle, live streaming (text asserted visible before the `done` frame), smart autoscroll, history persistence, logout→re-pair privacy flow, and a dashboard regression check with every `/api/**` endpoint stubbed to return `{}`.
- If any command is intentionally skipped, explain why: `cargo fmt/clippy/test` skipped locally — no Rust files touched (`web/` + `.gitignore` only); CI Stable Core jobs run them regardless.

## Quality Delta (required for medium/high risk changes)

- Quality delta required? (`Yes/No`): No (low risk)
- Expected panic count impact (production path): 0 (normalization removes render crashes on malformed responses)
- Expected unwrap count impact (production path): 0
- Expected flaky test rate impact: 0 (new unit tests are pure-function and deterministic)
- Expected critical-path test coverage impact: positive (normalizers fully unit-tested)

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: n/a — normalization narrows trust in gateway responses (unexpected shapes are coerced, not rendered); logout now clears session-scoped in-memory chat history and drafts, tightening the privacy boundary.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: none needed; no real data in fixtures.
- Neutral wording confirmation (use R.A.I.N./project-native labels if identity-like wording is needed): confirmed — test fixtures use neutral project-scoped labels (`test-model`, factory key `openai`); i18n keys are project-native.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): Yes — web app UI strings only.
- Locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md`? N/A — no docs IA or runtime-contract docs changed.
- New web UI keys (`nav.main_navigation`, `nav.open_menu`, `nav.close_menu`, `header.switch_language`) added to all web app locales (`en`, `zh`, `tr`).
- Localized runtime-contract docs updated? N/A (no runtime-surface behavior change).

## Human Verification (required)

- Verified scenarios: mobile drawer open/close/route-dismiss; streamed text visible before completion; autoscroll held back while scrolled up; history + partial reply preserved across navigation; logout→re-pair shows an empty conversation; dashboard renders with all APIs returning `{}` (screenshots captured in session).
- Edge cases checked: non-object payloads (null/string/number/array), NaN numbers, non-boolean channel flags, missing `by_model` names, mid-stream unmount, logout racing an in-flight stream.
- What was not verified: a live Rust gateway over WebSocket (mocked WS frames used); non-Chromium browsers.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `web/` dashboard only (layout shell, agent chat, dashboard/cost pages, API client, auth/draft hooks).
- Potential unintended effects: normalization could mask a misbehaving gateway by showing zeroed values — mitigated because failed HTTP requests still surface the existing error banner and the error boundary remains as last resort.
- Guardrails/monitoring for early detection: unit tests on normalizers; "—" placeholders make defaulted values visually distinct.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Claude Code (remote session).
- Workflow/plan summary (if any): read-first survey of `web/src`, minimal patches per concern, browser-level end-to-end verification in addition to unit tests.
- Verification focus: streaming/scroll behavior, mobile drawer, empty-API resilience, logout privacy boundary.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert a160761 5afc9a9 5d82ea0` — three isolated web-only commits; no data/config migration.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: dashboard error boundary ("Something went wrong"), missing sidebar on desktop, chat not rendering streamed text, stale conversation visible after re-pairing.

## Risks and Mitigations

- `.gitignore` anchor change could expose previously ignored paths → checked: `web/src/lib` is the only `lib/` directory in the repo; `git status` clean after the change.
- Drawer z-index sits above the security banner → scoped to the mobile drawer + overlay only; visually verified on desktop and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDk6rpjb92TE9cxEgADR2F