### PR TITLE
fix(autonomy): flush episodic event writes to eliminate append race (#368)

### DIFF
--- a/src/autonomy/episodic.rs
+++ b/src/autonomy/episodic.rs
@@ -165,6 +165,11 @@ pub async fn append_event(workspace_dir: &Path, event: &EpisodicEventV2) -> Resu
     file.write_all(line.as_bytes())
         .await
         .context("append episodic event")?;
+    // tokio::fs::File buffers writes onto a background blocking task; write_all
+    // can return before the bytes reach the OS, and dropping the handle does
+    // not wait for them. Flush explicitly so a following read (or a fast
+    // shutdown) always observes the appended line.
+    file.flush().await.context("flush episodic event")?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Base branch target (`main` for all contributions): `main`
- Problem: `append_event` (src/autonomy/episodic.rs) wrote via `tokio::fs::File::write_all` and dropped the handle without flushing. `tokio::fs::File` dispatches writes to a background blocking task, so `write_all` can return before the bytes reach the OS, and dropping the handle does not wait for them. A following read — or a fast shutdown — can miss a just-appended line.
- Why it matters: (1) a real production window where episodic events are silently lost on shutdown; (2) a non-deterministic CI failure — two tests intermittently see 1 line where 2 were written, which has been red-flagging unrelated PRs (e.g. #367) and violates the determinism contract in CLAUDE.md §3.7.
- What changed: added a single `file.flush().await` before returning from `append_event`. Both flaky tests go through this one function, so one flush fixes both and closes the production event-loss window.
- What did **not** change (scope boundary): no API/schema/behavior change beyond durability; write format and call sites are untouched.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: (auto-managed)
- Scope labels: `runtime`, `tests`
- Module labels: n/a
- Contributor tier label: (auto-managed)
- Auto-label corrections: none

## Change Metadata

- Change type: `bug`
- Primary scope: `runtime`

## Linked Issue

- Closes #368
- Related #367 (the flaky test was blocking that PR's merge)

## Validation Evidence (required)

Commands and result summary:

```bash
# Both affected tests, 5 consecutive runs — previously intermittently red in CI
cargo test --lib -- \
  autonomy::episodic::tests::append_event_creates_stream_and_appends_lines \
  hooks::builtin::episodic_events::tests::writes_v2_event_per_tool_call_without_payloads
# => 5/5 runs: test result: ok. 2 passed; 0 failed

cargo fmt --all -- --check   # clean
```

- Evidence provided: 5/5 deterministic passes of the two tests that were flaky in CI; the failure signature was `assertion left == right / left: 1 / right: 2` (one JSONL line observed where two were appended).
- If any command is intentionally skipped, explain why: full `cargo clippy --all-targets`/`cargo test` delegated to the Quality Gate CI on this PR; the change is a single added `.await` on an already-imported trait method.

## Quality Delta (required for medium/high risk changes)

- Quality delta required? (`Yes/No`): No (low risk, single-line durability fix)
- Expected panic count impact (production path): 0
- Expected unwrap count impact (production path): 0
- Expected flaky test rate impact: negative (removes two known flaky tests)
- Expected critical-path test coverage impact: unchanged (existing tests now deterministic)

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: n/a

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: none
- Neutral wording confirmation (use R.A.I.N./project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No — no user-facing wording changed

## Human Verification (required)

- Verified scenarios: appended two events and read the stream back 5 times in a row without loss; confirmed both previously-flaky tests share the `append_event` code path.
- Edge cases checked: the sibling hook test (`hooks::builtin::episodic_events`) writes through the same function, so it is covered by the same fix.
- What was not verified: crash-during-write durability (a `sync_data` would be needed for power-loss guarantees; out of scope — this fix targets the buffered-write ordering that caused the loss/flakiness).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: episodic event append path (`autonomy::episodic`), used by the `episodic_events` hook after each tool call.
- Potential unintended effects: an extra flush per append adds negligible latency on an already-async, low-frequency write.
- Guardrails/monitoring for early detection: the two now-deterministic tests fail loudly if the ordering guarantee regresses.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Claude Code (remote session).
- Workflow/plan summary (if any): diagnosed from CI logs (issue #368), traced both flaky tests to one function, applied the minimal durability fix.
- Verification focus: determinism across repeated runs.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert b9c5ceb` (single-line change)
- Feature flags or config toggles (if any): none
- Observable failure symptoms: recurrence of the intermittent `left: 1 / right: 2` episodic test failures

## Risks and Mitigations

- Risk: none material — flush before drop is the documented-correct usage of `tokio::fs::File`. Mitigation: covered by the two now-deterministic tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDk6rpjb92TE9cxEgADR2F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDk6rpjb92TE9cxEgADR2F)_